### PR TITLE
Add Qt4

### DIFF
--- a/qt4/qt4-4.8.7-minimal.json
+++ b/qt4/qt4-4.8.7-minimal.json
@@ -1,0 +1,86 @@
+{
+    "name": "qt4",
+    "config-opts": [
+        "-verbose",
+        "-confirm-license",
+        "-opensource",
+        "-release",
+        "-shared",
+        "-no-static",
+        "-fast",
+        "-datadir", "/app/lib/qt4",
+        "-importdir", "/app/lib/qt4/imports",
+        "-plugindir", "/app/lib/qt4/plugins",
+        "-translationdir", "/app/share/qt4/translations",
+        "-accessibility",
+        "-exceptions",
+        "-fontconfig",
+        "-glib",
+        "-dbus-linked",
+        "-openssl-linked",
+        "-optimized-qmake",
+        "-system-libjpeg",
+        "-system-libpng",
+        "-system-libtiff",
+        "-system-proxies",
+        "-system-zlib",
+        "-no-cups",
+        "-no-declarative",
+        "-no-gtkstyle",
+        "-no-javascript-jit",
+        "-no-libmng",
+        "-no-multimedia",
+        "-no-nis",
+        "-no-opengl",
+        "-no-phonon",
+        "-no-phonon-backend",
+        "-no-qt3support",
+        "-no-rpath",
+        "-no-script",
+        "-no-scripttools",
+        "-no-sql-db2",
+        "-no-sql-ibase",
+        "-no-sql-mysql",
+        "-no-sql-oci",
+        "-no-sql-odbc",
+        "-no-sql-psql",
+        "-no-sql-sqlite",
+        "-no-sql-sqlite2",
+        "-no-sql-sqlite_symbian",
+        "-no-sql-symsql",
+        "-no-sql-tds",
+        "-no-svg",
+        "-no-webkit",
+        "-no-xmlpatterns",
+        "-nomake", "demos",
+        "-nomake", "docs",
+        "-nomake", "examples"
+    ],
+    "build-options": {
+        "env": {
+            "CXXFLAGS": "-std=gnu++98",
+            "LD_LIBRARY_PATH": "/run/build/qt4/lib/"
+        }
+    },
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz",
+            "sha256": "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
+        },
+        {
+            "type": "patch",
+            "path": "shared-modules/qt4-aarch64.patch"
+        }
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/*.a",
+        "/lib/*.la",
+        "/lib/*.prl",
+        "/lib/pkgconfig",
+        "/lib/qt4/mkspecs",
+        "/lib/qt4/q3porting.xml"
+    ]
+}

--- a/qt4/qt4-aarch64.patch
+++ b/qt4/qt4-aarch64.patch
@@ -1,0 +1,514 @@
+diff -up qt-everywhere-opensource-src-4.8.7/include/QtCore/headers.pri.aarch64 qt-everywhere-opensource-src-4.8.7/include/QtCore/headers.pri
+--- qt-everywhere-opensource-src-4.8.7/include/QtCore/headers.pri.aarch64	2015-05-08 21:48:32.714057739 -0500
++++ qt-everywhere-opensource-src-4.8.7/include/QtCore/headers.pri	2015-05-08 21:53:21.088761971 -0500
+@@ -1,3 +1,3 @@
+-SYNCQT.HEADER_FILES = ../corelib/kernel/qabstracteventdispatcher.h ../corelib/kernel/qabstractitemmodel.h ../corelib/kernel/qbasictimer.h ../corelib/kernel/qcoreapplication.h ../corelib/kernel/qcoreevent.h ../corelib/kernel/qeventloop.h ../corelib/kernel/qfunctions_nacl.h ../corelib/kernel/qfunctions_vxworks.h ../corelib/kernel/qfunctions_wince.h ../corelib/kernel/qmath.h ../corelib/kernel/qmetaobject.h ../corelib/kernel/qmetatype.h ../corelib/kernel/qmimedata.h ../corelib/kernel/qobject.h ../corelib/kernel/qobjectcleanuphandler.h ../corelib/kernel/qobjectdefs.h ../corelib/kernel/qpointer.h ../corelib/kernel/qsharedmemory.h ../corelib/kernel/qsignalmapper.h ../corelib/kernel/qsocketnotifier.h ../corelib/kernel/qsystemsemaphore.h ../corelib/kernel/qtimer.h ../corelib/kernel/qtranslator.h ../corelib/kernel/qvariant.h ../corelib/animation/qabstractanimation.h ../corelib/animation/qanimationgroup.h ../corelib/animation/qparallelanimationgroup.h ../corelib/animation/qpauseanimation.h ../corelib/animation/qpropertyanimation.h ../corelib/animation/qsequentialanimationgroup.h ../corelib/animation/qvariantanimation.h ../corelib/arch/qatomic_alpha.h ../corelib/arch/qatomic_arch.h ../corelib/arch/qatomic_arm.h ../corelib/arch/qatomic_armv5.h ../corelib/arch/qatomic_armv6.h ../corelib/arch/qatomic_armv7.h ../corelib/arch/qatomic_avr32.h ../corelib/arch/qatomic_bfin.h ../corelib/arch/qatomic_bootstrap.h ../corelib/arch/qatomic_generic.h ../corelib/arch/qatomic_i386.h ../corelib/arch/qatomic_ia64.h ../corelib/arch/qatomic_integrity.h ../corelib/arch/qatomic_m68k.h ../corelib/arch/qatomic_macosx.h ../corelib/arch/qatomic_mips.h ../corelib/arch/qatomic_parisc.h ../corelib/arch/qatomic_powerpc.h ../corelib/arch/qatomic_s390.h ../corelib/arch/qatomic_sh.h ../corelib/arch/qatomic_sh4a.h ../corelib/arch/qatomic_sparc.h ../corelib/arch/qatomic_symbian.h ../corelib/arch/qatomic_vxworks.h ../corelib/arch/qatomic_windows.h ../corelib/arch/qatomic_windowsce.h ../corelib/arch/qatomic_x86_64.h ../corelib/tools/qalgorithms.h ../corelib/tools/qbitarray.h ../corelib/tools/qbytearray.h ../corelib/tools/qbytearraymatcher.h ../corelib/tools/qcache.h ../corelib/tools/qchar.h ../corelib/tools/qcontainerfwd.h ../corelib/tools/qcontiguouscache.h ../corelib/tools/qcryptographichash.h ../corelib/tools/qdatetime.h ../corelib/tools/qeasingcurve.h ../corelib/tools/qelapsedtimer.h ../corelib/tools/qhash.h ../corelib/tools/qiterator.h ../corelib/tools/qline.h ../corelib/tools/qlinkedlist.h ../corelib/tools/qlist.h ../corelib/tools/qlocale.h ../corelib/tools/qlocale_blackberry.h ../corelib/tools/qmap.h ../corelib/tools/qmargins.h ../corelib/tools/qpair.h ../corelib/tools/qpoint.h ../corelib/tools/qqueue.h ../corelib/tools/qrect.h ../corelib/tools/qregexp.h ../corelib/tools/qscopedpointer.h ../corelib/tools/qscopedvaluerollback.h ../corelib/tools/qset.h ../corelib/tools/qshareddata.h ../corelib/tools/qsharedpointer.h ../corelib/tools/qsharedpointer_impl.h ../corelib/tools/qsize.h ../corelib/tools/qstack.h ../corelib/tools/qstring.h ../corelib/tools/qstringbuilder.h ../corelib/tools/qstringlist.h ../corelib/tools/qstringmatcher.h ../corelib/tools/qtextboundaryfinder.h ../corelib/tools/qtimeline.h ../corelib/tools/qvarlengtharray.h ../corelib/tools/qvector.h ../corelib/plugin/qfactoryinterface.h ../corelib/plugin/qlibrary.h ../corelib/plugin/qplugin.h ../corelib/plugin/qpluginloader.h ../corelib/plugin/quuid.h ../corelib/xml/qxmlstream.h ../corelib/thread/qatomic.h ../corelib/thread/qbasicatomic.h ../corelib/thread/qmutex.h ../corelib/thread/qreadwritelock.h ../corelib/thread/qsemaphore.h ../corelib/thread/qthread.h ../corelib/thread/qthreadstorage.h ../corelib/thread/qwaitcondition.h ../corelib/statemachine/qabstractstate.h ../corelib/statemachine/qabstracttransition.h ../corelib/statemachine/qeventtransition.h ../corelib/statemachine/qfinalstate.h ../corelib/statemachine/qhistorystate.h ../corelib/statemachine/qsignaltransition.h ../corelib/statemachine/qstate.h ../corelib/statemachine/qstatemachine.h ../corelib/concurrent/qfuture.h ../corelib/concurrent/qfutureinterface.h ../corelib/concurrent/qfuturesynchronizer.h ../corelib/concurrent/qfuturewatcher.h ../corelib/concurrent/qrunnable.h ../corelib/concurrent/qtconcurrentcompilertest.h ../corelib/concurrent/qtconcurrentexception.h ../corelib/concurrent/qtconcurrentfilter.h ../corelib/concurrent/qtconcurrentfilterkernel.h ../corelib/concurrent/qtconcurrentfunctionwrappers.h ../corelib/concurrent/qtconcurrentiteratekernel.h ../corelib/concurrent/qtconcurrentmap.h ../corelib/concurrent/qtconcurrentmapkernel.h ../corelib/concurrent/qtconcurrentmedian.h ../corelib/concurrent/qtconcurrentreducekernel.h ../corelib/concurrent/qtconcurrentresultstore.h ../corelib/concurrent/qtconcurrentrun.h ../corelib/concurrent/qtconcurrentrunbase.h ../corelib/concurrent/qtconcurrentstoredfunctioncall.h ../corelib/concurrent/qtconcurrentthreadengine.h ../corelib/concurrent/qthreadpool.h ../corelib/io/qabstractfileengine.h ../corelib/io/qbuffer.h ../corelib/io/qdatastream.h ../corelib/io/qdebug.h ../corelib/io/qdir.h ../corelib/io/qdiriterator.h ../corelib/io/qfile.h ../corelib/io/qfileinfo.h ../corelib/io/qfilesystemwatcher.h ../corelib/io/qfsfileengine.h ../corelib/io/qiodevice.h ../corelib/io/qprocess.h ../corelib/io/qresource.h ../corelib/io/qsettings.h ../corelib/io/qtemporaryfile.h ../corelib/io/qtextstream.h ../corelib/io/qurl.h ../corelib/global/qconfig-dist.h ../corelib/global/qconfig-large.h ../corelib/global/qconfig-medium.h ../corelib/global/qconfig-minimal.h ../corelib/global/qconfig-nacl.h ../corelib/global/qconfig-small.h ../corelib/global/qendian.h ../corelib/global/qfeatures.h ../corelib/global/qglobal.h ../corelib/global/qlibraryinfo.h ../corelib/global/qnamespace.h ../corelib/global/qnumeric.h ../corelib/global/qt_windows.h ../corelib/global/qconfig.h ../corelib/codecs/qtextcodec.h ../corelib/codecs/qtextcodecplugin.h ../../include/QtCore/QtCore 
++SYNCQT.HEADER_FILES = ../corelib/kernel/qabstracteventdispatcher.h ../corelib/kernel/qabstractitemmodel.h ../corelib/kernel/qbasictimer.h ../corelib/kernel/qcoreapplication.h ../corelib/kernel/qcoreevent.h ../corelib/kernel/qeventloop.h ../corelib/kernel/qfunctions_nacl.h ../corelib/kernel/qfunctions_vxworks.h ../corelib/kernel/qfunctions_wince.h ../corelib/kernel/qmath.h ../corelib/kernel/qmetaobject.h ../corelib/kernel/qmetatype.h ../corelib/kernel/qmimedata.h ../corelib/kernel/qobject.h ../corelib/kernel/qobjectcleanuphandler.h ../corelib/kernel/qobjectdefs.h ../corelib/kernel/qpointer.h ../corelib/kernel/qsharedmemory.h ../corelib/kernel/qsignalmapper.h ../corelib/kernel/qsocketnotifier.h ../corelib/kernel/qsystemsemaphore.h ../corelib/kernel/qtimer.h ../corelib/kernel/qtranslator.h ../corelib/kernel/qvariant.h ../corelib/animation/qabstractanimation.h ../corelib/animation/qanimationgroup.h ../corelib/animation/qparallelanimationgroup.h ../corelib/animation/qpauseanimation.h ../corelib/animation/qpropertyanimation.h ../corelib/animation/qsequentialanimationgroup.h ../corelib/animation/qvariantanimation.h ../corelib/arch/qatomic_aarch64.h ../corelib/arch/qatomic_alpha.h ../corelib/arch/qatomic_arch.h ../corelib/arch/qatomic_arm.h ../corelib/arch/qatomic_armv5.h ../corelib/arch/qatomic_armv6.h ../corelib/arch/qatomic_armv7.h ../corelib/arch/qatomic_avr32.h ../corelib/arch/qatomic_bfin.h ../corelib/arch/qatomic_bootstrap.h ../corelib/arch/qatomic_generic.h ../corelib/arch/qatomic_i386.h ../corelib/arch/qatomic_ia64.h ../corelib/arch/qatomic_integrity.h ../corelib/arch/qatomic_m68k.h ../corelib/arch/qatomic_macosx.h ../corelib/arch/qatomic_mips.h ../corelib/arch/qatomic_parisc.h ../corelib/arch/qatomic_powerpc.h ../corelib/arch/qatomic_s390.h ../corelib/arch/qatomic_sh.h ../corelib/arch/qatomic_sh4a.h ../corelib/arch/qatomic_sparc.h ../corelib/arch/qatomic_symbian.h ../corelib/arch/qatomic_vxworks.h ../corelib/arch/qatomic_windows.h ../corelib/arch/qatomic_windowsce.h ../corelib/arch/qatomic_x86_64.h ../corelib/tools/qalgorithms.h ../corelib/tools/qbitarray.h ../corelib/tools/qbytearray.h ../corelib/tools/qbytearraymatcher.h ../corelib/tools/qcache.h ../corelib/tools/qchar.h ../corelib/tools/qcontainerfwd.h ../corelib/tools/qcontiguouscache.h ../corelib/tools/qcryptographichash.h ../corelib/tools/qdatetime.h ../corelib/tools/qeasingcurve.h ../corelib/tools/qelapsedtimer.h ../corelib/tools/qhash.h ../corelib/tools/qiterator.h ../corelib/tools/qline.h ../corelib/tools/qlinkedlist.h ../corelib/tools/qlist.h ../corelib/tools/qlocale.h ../corelib/tools/qlocale_blackberry.h ../corelib/tools/qmap.h ../corelib/tools/qmargins.h ../corelib/tools/qpair.h ../corelib/tools/qpoint.h ../corelib/tools/qqueue.h ../corelib/tools/qrect.h ../corelib/tools/qregexp.h ../corelib/tools/qscopedpointer.h ../corelib/tools/qscopedvaluerollback.h ../corelib/tools/qset.h ../corelib/tools/qshareddata.h ../corelib/tools/qsharedpointer.h ../corelib/tools/qsharedpointer_impl.h ../corelib/tools/qsize.h ../corelib/tools/qstack.h ../corelib/tools/qstring.h ../corelib/tools/qstringbuilder.h ../corelib/tools/qstringlist.h ../corelib/tools/qstringmatcher.h ../corelib/tools/qtextboundaryfinder.h ../corelib/tools/qtimeline.h ../corelib/tools/qvarlengtharray.h ../corelib/tools/qvector.h ../corelib/plugin/qfactoryinterface.h ../corelib/plugin/qlibrary.h ../corelib/plugin/qplugin.h ../corelib/plugin/qpluginloader.h ../corelib/plugin/quuid.h ../corelib/xml/qxmlstream.h ../corelib/thread/qatomic.h ../corelib/thread/qbasicatomic.h ../corelib/thread/qmutex.h ../corelib/thread/qreadwritelock.h ../corelib/thread/qsemaphore.h ../corelib/thread/qthread.h ../corelib/thread/qthreadstorage.h ../corelib/thread/qwaitcondition.h ../corelib/statemachine/qabstractstate.h ../corelib/statemachine/qabstracttransition.h ../corelib/statemachine/qeventtransition.h ../corelib/statemachine/qfinalstate.h ../corelib/statemachine/qhistorystate.h ../corelib/statemachine/qsignaltransition.h ../corelib/statemachine/qstate.h ../corelib/statemachine/qstatemachine.h ../corelib/concurrent/qfuture.h ../corelib/concurrent/qfutureinterface.h ../corelib/concurrent/qfuturesynchronizer.h ../corelib/concurrent/qfuturewatcher.h ../corelib/concurrent/qrunnable.h ../corelib/concurrent/qtconcurrentcompilertest.h ../corelib/concurrent/qtconcurrentexception.h ../corelib/concurrent/qtconcurrentfilter.h ../corelib/concurrent/qtconcurrentfilterkernel.h ../corelib/concurrent/qtconcurrentfunctionwrappers.h ../corelib/concurrent/qtconcurrentiteratekernel.h ../corelib/concurrent/qtconcurrentmap.h ../corelib/concurrent/qtconcurrentmapkernel.h ../corelib/concurrent/qtconcurrentmedian.h ../corelib/concurrent/qtconcurrentreducekernel.h ../corelib/concurrent/qtconcurrentresultstore.h ../corelib/concurrent/qtconcurrentrun.h ../corelib/concurrent/qtconcurrentrunbase.h ../corelib/concurrent/qtconcurrentstoredfunctioncall.h ../corelib/concurrent/qtconcurrentthreadengine.h ../corelib/concurrent/qthreadpool.h ../corelib/io/qabstractfileengine.h ../corelib/io/qbuffer.h ../corelib/io/qdatastream.h ../corelib/io/qdebug.h ../corelib/io/qdir.h ../corelib/io/qdiriterator.h ../corelib/io/qfile.h ../corelib/io/qfileinfo.h ../corelib/io/qfilesystemwatcher.h ../corelib/io/qfsfileengine.h ../corelib/io/qiodevice.h ../corelib/io/qprocess.h ../corelib/io/qresource.h ../corelib/io/qsettings.h ../corelib/io/qtemporaryfile.h ../corelib/io/qtextstream.h ../corelib/io/qurl.h ../corelib/global/qconfig-dist.h ../corelib/global/qconfig-large.h ../corelib/global/qconfig-medium.h ../corelib/global/qconfig-minimal.h ../corelib/global/qconfig-nacl.h ../corelib/global/qconfig-small.h ../corelib/global/qendian.h ../corelib/global/qfeatures.h ../corelib/global/qglobal.h ../corelib/global/qlibraryinfo.h ../corelib/global/qnamespace.h ../corelib/global/qnumeric.h ../corelib/global/qt_windows.h ../corelib/global/qconfig.h ../corelib/codecs/qtextcodec.h ../corelib/codecs/qtextcodecplugin.h ../../include/QtCore/QtCore 
+ SYNCQT.HEADER_CLASSES = ../../include/QtCore/QAbstractEventDispatcher ../../include/QtCore/QModelIndex ../../include/QtCore/QPersistentModelIndex ../../include/QtCore/QModelIndexList ../../include/QtCore/QAbstractItemModel ../../include/QtCore/QAbstractTableModel ../../include/QtCore/QAbstractListModel ../../include/QtCore/QBasicTimer ../../include/QtCore/QCoreApplication ../../include/QtCore/QtCleanUpFunction ../../include/QtCore/QEvent ../../include/QtCore/QTimerEvent ../../include/QtCore/QChildEvent ../../include/QtCore/QCustomEvent ../../include/QtCore/QDynamicPropertyChangeEvent ../../include/QtCore/QEventLoop ../../include/QtCore/QMetaMethod ../../include/QtCore/QMetaEnum ../../include/QtCore/QMetaProperty ../../include/QtCore/QMetaClassInfo ../../include/QtCore/QMetaType ../../include/QtCore/QMetaTypeId ../../include/QtCore/QMetaTypeId2 ../../include/QtCore/QMimeData ../../include/QtCore/QObjectList ../../include/QtCore/QObjectData ../../include/QtCore/QObject ../../include/QtCore/QObjectUserData ../../include/QtCore/QObjectCleanupHandler ../../include/QtCore/QGenericArgument ../../include/QtCore/QGenericReturnArgument ../../include/QtCore/QArgument ../../include/QtCore/QReturnArgument ../../include/QtCore/QMetaObject ../../include/QtCore/QMetaObjectAccessor ../../include/QtCore/QMetaObjectExtraData ../../include/QtCore/QPointer ../../include/QtCore/QSharedMemory ../../include/QtCore/QSignalMapper ../../include/QtCore/QSocketNotifier ../../include/QtCore/QSystemSemaphore ../../include/QtCore/QTimer ../../include/QtCore/QTranslator ../../include/QtCore/QVariant ../../include/QtCore/QVariantList ../../include/QtCore/QVariantMap ../../include/QtCore/QVariantHash ../../include/QtCore/QVariantComparisonHelper ../../include/QtCore/QAbstractAnimation ../../include/QtCore/QAnimationDriver ../../include/QtCore/QAnimationGroup ../../include/QtCore/QParallelAnimationGroup ../../include/QtCore/QPauseAnimation ../../include/QtCore/QPropertyAnimation ../../include/QtCore/QSequentialAnimationGroup ../../include/QtCore/QVariantAnimation ../../include/QtCore/QtAlgorithms ../../include/QtCore/QBitArray ../../include/QtCore/QBitRef ../../include/QtCore/QByteArray ../../include/QtCore/QByteRef ../../include/QtCore/QByteArrayMatcher ../../include/QtCore/QCache ../../include/QtCore/QLatin1Char ../../include/QtCore/QChar ../../include/QtCore/QtContainerFwd ../../include/QtCore/QContiguousCacheData ../../include/QtCore/QContiguousCacheTypedData ../../include/QtCore/QContiguousCache ../../include/QtCore/QCryptographicHash ../../include/QtCore/QDate ../../include/QtCore/QTime ../../include/QtCore/QDateTime ../../include/QtCore/QEasingCurve ../../include/QtCore/QElapsedTimer ../../include/QtCore/QHashData ../../include/QtCore/QHashDummyValue ../../include/QtCore/QHashDummyNode ../../include/QtCore/QHashNode ../../include/QtCore/QHash ../../include/QtCore/QMultiHash ../../include/QtCore/QHashIterator ../../include/QtCore/QMutableHashIterator ../../include/QtCore/QLine ../../include/QtCore/QLineF ../../include/QtCore/QLinkedListData ../../include/QtCore/QLinkedListNode ../../include/QtCore/QLinkedList ../../include/QtCore/QLinkedListIterator ../../include/QtCore/QMutableLinkedListIterator ../../include/QtCore/QListData ../../include/QtCore/QList ../../include/QtCore/QListIterator ../../include/QtCore/QMutableListIterator ../../include/QtCore/QSystemLocale ../../include/QtCore/QLocale ../../include/QtCore/QBBSystemLocaleData ../../include/QtCore/QMapData ../../include/QtCore/QMapNode ../../include/QtCore/QMapPayloadNode ../../include/QtCore/QMap ../../include/QtCore/QMultiMap ../../include/QtCore/QMapIterator ../../include/QtCore/QMutableMapIterator ../../include/QtCore/QMargins ../../include/QtCore/QPair ../../include/QtCore/QPoint ../../include/QtCore/QPointF ../../include/QtCore/QQueue ../../include/QtCore/QRect ../../include/QtCore/QRectF ../../include/QtCore/QRegExp ../../include/QtCore/QScopedPointerDeleter ../../include/QtCore/QScopedPointerArrayDeleter ../../include/QtCore/QScopedPointerPodDeleter ../../include/QtCore/QScopedPointer ../../include/QtCore/QScopedArrayPointer ../../include/QtCore/QScopedValueRollback ../../include/QtCore/QSet ../../include/QtCore/QSetIterator ../../include/QtCore/QMutableSetIterator ../../include/QtCore/QSharedData ../../include/QtCore/QSharedDataPointer ../../include/QtCore/QExplicitlySharedDataPointer ../../include/QtCore/QSharedPointer ../../include/QtCore/QWeakPointer ../../include/QtCore/QSize ../../include/QtCore/QSizeF ../../include/QtCore/QStack ../../include/QtCore/QStdWString ../../include/QtCore/QString ../../include/QtCore/QLatin1String ../../include/QtCore/QCharRef ../../include/QtCore/QConstString ../../include/QtCore/QStringRef ../../include/QtCore/QLatin1Literal ../../include/QtCore/QAbstractConcatenable ../../include/QtCore/QConcatenable ../../include/QtCore/QStringBuilder ../../include/QtCore/QStringListIterator ../../include/QtCore/QMutableStringListIterator ../../include/QtCore/QStringList ../../include/QtCore/QStringMatcher ../../include/QtCore/QTextBoundaryFinder ../../include/QtCore/QTimeLine ../../include/QtCore/QVarLengthArray ../../include/QtCore/QVectorData ../../include/QtCore/QVectorTypedData ../../include/QtCore/QVector ../../include/QtCore/QVectorIterator ../../include/QtCore/QMutableVectorIterator ../../include/QtCore/QFactoryInterface ../../include/QtCore/QLibrary ../../include/QtCore/QtPlugin ../../include/QtCore/QtPluginInstanceFunction ../../include/QtCore/QPluginLoader ../../include/QtCore/QUuid ../../include/QtCore/QXmlStreamStringRef ../../include/QtCore/QXmlStreamAttribute ../../include/QtCore/QXmlStreamAttributes ../../include/QtCore/QXmlStreamNamespaceDeclaration ../../include/QtCore/QXmlStreamNamespaceDeclarations ../../include/QtCore/QXmlStreamNotationDeclaration ../../include/QtCore/QXmlStreamNotationDeclarations ../../include/QtCore/QXmlStreamEntityDeclaration ../../include/QtCore/QXmlStreamEntityDeclarations ../../include/QtCore/QXmlStreamEntityResolver ../../include/QtCore/QXmlStreamReader ../../include/QtCore/QXmlStreamWriter ../../include/QtCore/QAtomicInt ../../include/QtCore/QAtomicPointer ../../include/QtCore/QBasicAtomicInt ../../include/QtCore/QBasicAtomicPointer ../../include/QtCore/QMutex ../../include/QtCore/QMutexLocker ../../include/QtCore/QMutexData ../../include/QtCore/QReadWriteLock ../../include/QtCore/QReadLocker ../../include/QtCore/QWriteLocker ../../include/QtCore/QSemaphore ../../include/QtCore/QThread ../../include/QtCore/QThreadStorageData ../../include/QtCore/QThreadStorage ../../include/QtCore/QWaitCondition ../../include/QtCore/QAbstractState ../../include/QtCore/QAbstractTransition ../../include/QtCore/QEventTransition ../../include/QtCore/QFinalState ../../include/QtCore/QHistoryState ../../include/QtCore/QSignalTransition ../../include/QtCore/QState ../../include/QtCore/QStateMachine ../../include/QtCore/QFuture ../../include/QtCore/QFutureIterator ../../include/QtCore/QMutableFutureIterator ../../include/QtCore/QFutureInterfaceBase ../../include/QtCore/QFutureInterface ../../include/QtCore/QFutureSynchronizer ../../include/QtCore/QFutureWatcherBase ../../include/QtCore/QFutureWatcher ../../include/QtCore/QRunnable ../../include/QtCore/QtConcurrentFilter ../../include/QtCore/QtConcurrentMap ../../include/QtCore/QtConcurrentRun ../../include/QtCore/QThreadPool ../../include/QtCore/QAbstractFileEngine ../../include/QtCore/QAbstractFileEngineHandler ../../include/QtCore/QAbstractFileEngineIterator ../../include/QtCore/QBuffer ../../include/QtCore/QDataStream ../../include/QtCore/QtDebug ../../include/QtCore/QDebug ../../include/QtCore/QNoDebug ../../include/QtCore/QDir ../../include/QtCore/QDirIterator ../../include/QtCore/QFile ../../include/QtCore/QFileInfo ../../include/QtCore/QFileInfoList ../../include/QtCore/QFileInfoListIterator ../../include/QtCore/QFileSystemWatcher ../../include/QtCore/QFSFileEngine ../../include/QtCore/QIODevice ../../include/QtCore/Q_PID ../../include/QtCore/QProcessEnvironment ../../include/QtCore/QProcess ../../include/QtCore/QResource ../../include/QtCore/QSettings ../../include/QtCore/QTemporaryFile ../../include/QtCore/QTextStream ../../include/QtCore/QTextStreamFunction ../../include/QtCore/QTextStreamManipulator ../../include/QtCore/QTS ../../include/QtCore/QTextIStream ../../include/QtCore/QTextOStream ../../include/QtCore/QUrl ../../include/QtCore/QtEndian ../../include/QtCore/QtGlobal ../../include/QtCore/QIntegerForSize ../../include/QtCore/QNoImplicitBoolCast ../../include/QtCore/Q_INT8 ../../include/QtCore/Q_UINT8 ../../include/QtCore/Q_INT16 ../../include/QtCore/Q_UINT16 ../../include/QtCore/Q_INT32 ../../include/QtCore/Q_UINT32 ../../include/QtCore/Q_INT64 ../../include/QtCore/Q_UINT64 ../../include/QtCore/Q_LLONG ../../include/QtCore/Q_ULLONG ../../include/QtCore/Q_LONG ../../include/QtCore/Q_ULONG ../../include/QtCore/QSysInfo ../../include/QtCore/QtMsgHandler ../../include/QtCore/QGlobalStatic ../../include/QtCore/QGlobalStaticDeleter ../../include/QtCore/QBool ../../include/QtCore/QTypeInfo ../../include/QtCore/QFlag ../../include/QtCore/QIncompatibleFlag ../../include/QtCore/QFlags ../../include/QtCore/QForeachContainer ../../include/QtCore/QForeachContainerBase ../../include/QtCore/QLibraryInfo ../../include/QtCore/Qt ../../include/QtCore/QInternal ../../include/QtCore/QCOORD ../../include/QtCore/QtConfig ../../include/QtCore/QTextCodec ../../include/QtCore/QTextEncoder ../../include/QtCore/QTextDecoder ../../include/QtCore/QTextCodecFactoryInterface ../../include/QtCore/QTextCodecPlugin 
+ SYNCQT.PRIVATE_HEADER_FILES = ../corelib/kernel/qabstracteventdispatcher_p.h ../corelib/kernel/qabstractitemmodel_p.h ../corelib/kernel/qcore_mac_p.h ../corelib/kernel/qcore_symbian_p.h ../corelib/kernel/qcore_unix_p.h ../corelib/kernel/qcoreapplication_p.h ../corelib/kernel/qcorecmdlineargs_p.h ../corelib/kernel/qcoreglobaldata_p.h ../corelib/kernel/qcrashhandler_p.h ../corelib/kernel/qeventdispatcher_blackberry_p.h ../corelib/kernel/qeventdispatcher_glib_p.h ../corelib/kernel/qeventdispatcher_symbian_p.h ../corelib/kernel/qeventdispatcher_unix_p.h ../corelib/kernel/qeventdispatcher_win_p.h ../corelib/kernel/qfunctions_p.h ../corelib/kernel/qmetaobject_p.h ../corelib/kernel/qobject_p.h ../corelib/kernel/qsharedmemory_p.h ../corelib/kernel/qsystemerror_p.h ../corelib/kernel/qsystemsemaphore_p.h ../corelib/kernel/qtranslator_p.h ../corelib/kernel/qvariant_p.h ../corelib/kernel/qwineventnotifier_p.h ../corelib/animation/qabstractanimation_p.h ../corelib/animation/qanimationgroup_p.h ../corelib/animation/qparallelanimationgroup_p.h ../corelib/animation/qpropertyanimation_p.h ../corelib/animation/qsequentialanimationgroup_p.h ../corelib/animation/qvariantanimation_p.h ../corelib/tools/qbytedata_p.h ../corelib/tools/qdatetime_p.h ../corelib/tools/qharfbuzz_p.h ../corelib/tools/qlocale_data_p.h ../corelib/tools/qlocale_p.h ../corelib/tools/qlocale_tools_p.h ../corelib/tools/qpodlist_p.h ../corelib/tools/qringbuffer_p.h ../corelib/tools/qscopedpointer_p.h ../corelib/tools/qsimd_p.h ../corelib/tools/qtools_p.h ../corelib/tools/qunicodetables_p.h ../corelib/plugin/qelfparser_p.h ../corelib/plugin/qfactoryloader_p.h ../corelib/plugin/qlibrary_p.h ../corelib/plugin/qsystemlibrary_p.h ../corelib/xml/qxmlstream_p.h ../corelib/xml/qxmlutils_p.h ../corelib/thread/qmutex_p.h ../corelib/thread/qmutexpool_p.h ../corelib/thread/qorderedmutexlocker_p.h ../corelib/thread/qreadwritelock_p.h ../corelib/thread/qthread_p.h ../corelib/statemachine/qabstractstate_p.h ../corelib/statemachine/qabstracttransition_p.h ../corelib/statemachine/qeventtransition_p.h ../corelib/statemachine/qhistorystate_p.h ../corelib/statemachine/qsignaleventgenerator_p.h ../corelib/statemachine/qsignaltransition_p.h ../corelib/statemachine/qstate_p.h ../corelib/statemachine/qstatemachine_p.h ../corelib/concurrent/qfutureinterface_p.h ../corelib/concurrent/qfuturewatcher_p.h ../corelib/concurrent/qthreadpool_p.h ../corelib/io/qabstractfileengine_p.h ../corelib/io/qdatastream_p.h ../corelib/io/qdataurl_p.h ../corelib/io/qdir_p.h ../corelib/io/qfile_p.h ../corelib/io/qfileinfo_p.h ../corelib/io/qfilesystemengine_p.h ../corelib/io/qfilesystementry_p.h ../corelib/io/qfilesystemiterator_p.h ../corelib/io/qfilesystemmetadata_p.h ../corelib/io/qfilesystemwatcher_dnotify_p.h ../corelib/io/qfilesystemwatcher_fsevents_p.h ../corelib/io/qfilesystemwatcher_inotify_p.h ../corelib/io/qfilesystemwatcher_kqueue_p.h ../corelib/io/qfilesystemwatcher_p.h ../corelib/io/qfilesystemwatcher_symbian_p.h ../corelib/io/qfilesystemwatcher_win_p.h ../corelib/io/qfsfileengine_iterator_p.h ../corelib/io/qfsfileengine_p.h ../corelib/io/qiodevice_p.h ../corelib/io/qnoncontiguousbytedevice_p.h ../corelib/io/qprocess_p.h ../corelib/io/qresource_iterator_p.h ../corelib/io/qresource_p.h ../corelib/io/qsettings_p.h ../corelib/io/qtldurl_p.h ../corelib/io/qurltlds_p.h ../corelib/io/qwindowspipewriter_p.h ../corelib/global/qnumeric_p.h ../corelib/global/qt_pch.h ../corelib/codecs/qfontlaocodec_p.h ../corelib/codecs/qiconvcodec_p.h ../corelib/codecs/qisciicodec_p.h ../corelib/codecs/qlatincodec_p.h ../corelib/codecs/qsimplecodec_p.h ../corelib/codecs/qtextcodec_p.h ../corelib/codecs/qtsciicodec_p.h ../corelib/codecs/qutfcodec_p.h 
+diff -up qt-everywhere-opensource-src-4.8.7/include/QtCore/qatomic_aarch64.h.aarch64 qt-everywhere-opensource-src-4.8.7/include/QtCore/qatomic_aarch64.h
+--- qt-everywhere-opensource-src-4.8.7/include/QtCore/qatomic_aarch64.h.aarch64	2015-05-08 21:48:32.715057744 -0500
++++ qt-everywhere-opensource-src-4.8.7/include/QtCore/qatomic_aarch64.h	2015-05-08 21:48:32.715057744 -0500
+@@ -0,0 +1 @@
++#include "../../src/corelib/arch/qatomic_aarch64.h"
+diff -up qt-everywhere-opensource-src-4.8.7/src/3rdparty/javascriptcore/JavaScriptCore/JavaScriptCore.pri.aarch64 qt-everywhere-opensource-src-4.8.7/src/3rdparty/javascriptcore/JavaScriptCore/JavaScriptCore.pri
+--- qt-everywhere-opensource-src-4.8.7/src/3rdparty/javascriptcore/JavaScriptCore/JavaScriptCore.pri.aarch64	2015-05-07 09:14:47.000000000 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/3rdparty/javascriptcore/JavaScriptCore/JavaScriptCore.pri	2015-05-08 21:48:33.268061013 -0500
+@@ -66,6 +66,12 @@ contains(JAVASCRIPTCORE_JIT,no) {
+     }
+ }
+ 
++# Hack around AARCH64 fail wrt JSValue.h
++equals(QT_ARCH, aarch64) {
++    message("JavaScriptCore aarch64 hack: -fpermissive")
++    QMAKE_CXXFLAGS += -fpermissive
++}
++
+ wince* {
+     INCLUDEPATH += $$QT_SOURCE_TREE/src/3rdparty/ce-compat
+     SOURCES += $$QT_SOURCE_TREE/src/3rdparty/ce-compat/ce_time.c
+diff -up qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/JavaScriptCore.pri.aarch64 qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/JavaScriptCore.pri
+--- qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/JavaScriptCore.pri.aarch64	2015-05-07 09:14:45.000000000 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/JavaScriptCore.pri	2015-05-08 21:48:33.268061013 -0500
+@@ -63,6 +63,12 @@ contains (CONFIG, text_breaking_with_icu
+     DEFINES += WTF_USE_QT_ICU_TEXT_BREAKING=1
+ }
+ 
++# Hack around AARCH64 fail wrt JSValue.h
++equals(QT_ARCH, aarch64) {
++    message("JavaScriptCore aarch64 hack: -fpermissive")
++    QMAKE_CXXFLAGS += -fpermissive
++}
++
+ wince* {
+     INCLUDEPATH += $$QT_SOURCE_TREE/src/3rdparty/ce-compat
+     INCLUDEPATH += $$PWD/../JavaScriptCore/os-win32
+diff -up qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/wtf/Platform.h.aarch64 qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/wtf/Platform.h
+--- qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/wtf/Platform.h.aarch64	2015-05-07 09:14:45.000000000 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/3rdparty/webkit/Source/JavaScriptCore/wtf/Platform.h	2015-05-08 21:48:33.269061019 -0500
+@@ -369,7 +369,16 @@
+ 
+ #endif /* ARM */
+ 
+-#if CPU(ARM) || CPU(MIPS) || CPU(SH4)
++/* CPU(AARCH64) - AArch64 */
++#if defined(__aarch64__)
++#define WTF_CPU_AARCH64 1
++#if defined(__AARCH64EB__)
++#define WTF_CPU_BIG_ENDIAN 1
++#endif
++#endif
++
++/* Not sure about this one, qt5-qtwebkit doesn't include it -- rex */
++#if CPU(ARM) || CPU(MIPS) || CPU(SH4) || CPU(AARCH64)
+ #define WTF_CPU_NEEDS_ALIGNED_ACCESS 1
+ #endif
+ 
+@@ -1003,7 +1012,7 @@
+     || CPU(SPARC64) \
+     || CPU(S390X) \
+     || CPU(PPC64) \
+-    || CPU(MIPS64)
++    || CPU(MIPS64) || CPU(AARCH64)
+ #define WTF_USE_JSVALUE64 1
+ #else
+ #define WTF_USE_JSVALUE32_64 1
+diff -up qt-everywhere-opensource-src-4.8.7/src/corelib/arch/aarch64/qatomic_aarch64.cpp.aarch64 qt-everywhere-opensource-src-4.8.7/src/corelib/arch/aarch64/qatomic_aarch64.cpp
+--- qt-everywhere-opensource-src-4.8.7/src/corelib/arch/aarch64/qatomic_aarch64.cpp.aarch64	2015-05-08 21:48:33.269061019 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/corelib/arch/aarch64/qatomic_aarch64.cpp	2015-05-08 21:48:33.269061019 -0500
+@@ -0,0 +1,70 @@
++/****************************************************************************
++**
++** Copyright (C) 2012, 2013 Digia Plc and/or its subsidiary(-ies).
++** Contact: http://www.qt-project.org/legal
++**
++** This file is part of the QtCore module of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and Digia.  For licensing terms and
++** conditions see http://qt.digia.com/licensing.  For further information
++** use the contact form at http://qt.digia.com/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 2.1 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL included in the
++** packaging of this file.  Please review the following information to
++** ensure the GNU Lesser General Public License version 2.1 requirements
++** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
++**
++** In addition, as a special exception, Digia gives you certain additional
++** rights.  These rights are described in the Digia Qt LGPL Exception
++** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 3.0 as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL included in the
++** packaging of this file.  Please review the following information to
++** ensure the GNU General Public License version 3.0 requirements will be
++** met: http://www.gnu.org/copyleft/gpl.html.
++**
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#include <QtCore/qglobal.h>
++
++#include <unistd.h>
++#ifdef _POSIX_PRIORITY_SCHEDULING
++# include <sched.h>
++#endif
++#include <time.h>
++
++QT_BEGIN_NAMESPACE
++
++QT_USE_NAMESPACE
++
++Q_CORE_EXPORT void qt_atomic_yield(int *count)
++{
++#ifdef _POSIX_PRIORITY_SCHEDULING
++    if((*count)++ < 50) {
++        sched_yield();
++    } else
++#endif
++    {
++        struct timespec tm;
++        tm.tv_sec = 0;
++        tm.tv_nsec = 2000001;
++        nanosleep(&tm, NULL);
++        *count = 0;
++    }
++}
++
++QT_END_NAMESPACE
+diff -up qt-everywhere-opensource-src-4.8.7/src/corelib/arch/arch.pri.aarch64 qt-everywhere-opensource-src-4.8.7/src/corelib/arch/arch.pri
+--- qt-everywhere-opensource-src-4.8.7/src/corelib/arch/arch.pri.aarch64	2015-05-07 09:14:48.000000000 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/corelib/arch/arch.pri	2015-05-08 21:48:33.270061025 -0500
+@@ -31,7 +31,9 @@ integrity:HEADERS += arch/qatomic_integr
+                        arch/qatomic_s390.h \
+                        arch/qatomic_x86_64.h \
+                        arch/qatomic_sh.h \
+-                       arch/qatomic_sh4a.h
++                       arch/qatomic_sh4a.h \
++                       arch/qatomic_aarch64.h \
++
+ 
+ QT_ARCH_CPP = $$QT_SOURCE_TREE/src/corelib/arch/$$QT_ARCH
+ DEPENDPATH += $$QT_ARCH_CPP
+diff -up qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_aarch64.h.aarch64 qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_aarch64.h
+--- qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_aarch64.h.aarch64	2015-05-08 21:48:33.270061025 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_aarch64.h	2015-05-08 21:48:33.270061025 -0500
+@@ -0,0 +1,335 @@
++/****************************************************************************
++**
++** Copyright (C) 2012 Digia Plc and/or its subsidiary(-ies).
++** Contact: http://www.qt-project.org/legal
++**
++** This file is part of the QtCore module of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and Digia.  For licensing terms and
++** conditions see http://qt.digia.com/licensing.  For further information
++** use the contact form at http://qt.digia.com/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 2.1 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL included in the
++** packaging of this file.  Please review the following information to
++** ensure the GNU Lesser General Public License version 2.1 requirements
++** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
++**
++** In addition, as a special exception, Digia gives you certain additional
++** rights.  These rights are described in the Digia Qt LGPL Exception
++** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 3.0 as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL included in the
++** packaging of this file.  Please review the following information to
++** ensure the GNU General Public License version 3.0 requirements will be
++** met: http://www.gnu.org/copyleft/gpl.html.
++**
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QATOMIC_AARCH64_H
++#define QATOMIC_AARCH64_H
++
++QT_BEGIN_HEADER
++
++QT_BEGIN_NAMESPACE
++
++#define Q_ATOMIC_INT_REFERENCE_COUNTING_IS_ALWAYS_NATIVE
++
++inline bool QBasicAtomicInt::isReferenceCountingNative()
++{ return true; }
++inline bool QBasicAtomicInt::isReferenceCountingWaitFree()
++{ return false; }
++
++#define Q_ATOMIC_INT_TEST_AND_SET_IS_ALWAYS_NATIVE
++
++inline bool QBasicAtomicInt::isTestAndSetNative()
++{ return true; }
++inline bool QBasicAtomicInt::isTestAndSetWaitFree()
++{ return false; }
++
++#define Q_ATOMIC_INT_FETCH_AND_STORE_IS_ALWAYS_NATIVE
++
++inline bool QBasicAtomicInt::isFetchAndStoreNative()
++{ return true; }
++inline bool QBasicAtomicInt::isFetchAndStoreWaitFree()
++{ return false; }
++
++#define Q_ATOMIC_INT_FETCH_AND_ADD_IS_ALWAYS_NATIVE
++
++inline bool QBasicAtomicInt::isFetchAndAddNative()
++{ return true; }
++inline bool QBasicAtomicInt::isFetchAndAddWaitFree()
++{ return false; }
++
++#define Q_ATOMIC_POINTER_TEST_AND_SET_IS_ALWAYS_NATIVE
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::isTestAndSetNative()
++{ return true; }
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::isTestAndSetWaitFree()
++{ return false; }
++
++#define Q_ATOMIC_POINTER_FETCH_AND_STORE_IS_ALWAYS_NATIVE
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::isFetchAndStoreNative()
++{ return true; }
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::isFetchAndStoreWaitFree()
++{ return false; }
++
++#define Q_ATOMIC_POINTER_FETCH_AND_ADD_IS_ALWAYS_NATIVE
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::isFetchAndAddNative()
++{ return true; }
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::isFetchAndAddWaitFree()
++{ return false; }
++
++#ifndef Q_DATA_MEMORY_BARRIER
++# define Q_DATA_MEMORY_BARRIER asm volatile("dmb sy\n":::"memory")
++#endif
++#ifndef Q_COMPILER_MEMORY_BARRIER
++# define Q_COMPILER_MEMORY_BARRIER asm volatile("":::"memory")
++#endif
++
++inline bool QBasicAtomicInt::ref()
++{
++    int newValue;
++
++    Q_COMPILER_MEMORY_BARRIER;
++    newValue = __atomic_add_fetch(&_q_value, 1, __ATOMIC_ACQ_REL);
++    Q_COMPILER_MEMORY_BARRIER;
++
++    return newValue != 0;
++}
++
++inline bool QBasicAtomicInt::deref()
++{
++    int newValue;
++
++    Q_COMPILER_MEMORY_BARRIER;
++    newValue = __atomic_sub_fetch(&_q_value, 1, __ATOMIC_ACQ_REL);
++    Q_COMPILER_MEMORY_BARRIER;
++
++    return newValue != 0;
++}
++
++inline bool QBasicAtomicInt::testAndSetRelaxed(int expectedValue, int newValue)
++{
++    bool val;
++
++    Q_COMPILER_MEMORY_BARRIER;
++    val =  __atomic_compare_exchange_n (&_q_value, &expectedValue, newValue,
++					false, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
++    Q_COMPILER_MEMORY_BARRIER;
++    return val;
++}
++
++inline int QBasicAtomicInt::fetchAndStoreRelaxed(int newValue)
++{
++    int val;
++    Q_COMPILER_MEMORY_BARRIER;
++    val = __atomic_exchange_n(&_q_value, newValue, __ATOMIC_RELAXED);
++    Q_COMPILER_MEMORY_BARRIER;
++    return val;
++}
++
++inline int QBasicAtomicInt::fetchAndAddRelaxed(int valueToAdd)
++{
++    int val;
++    Q_COMPILER_MEMORY_BARRIER;
++    val = __atomic_fetch_add(&_q_value, valueToAdd, __ATOMIC_RELAXED);
++    Q_COMPILER_MEMORY_BARRIER;
++    return val;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::testAndSetRelaxed(T *expectedValue, T *newValue)
++{
++    bool val;
++    Q_COMPILER_MEMORY_BARRIER;
++    val =  __atomic_compare_exchange_n (&_q_value, &expectedValue, newValue,
++					false, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
++    Q_COMPILER_MEMORY_BARRIER;
++    return val;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndStoreRelaxed(T *newValue)
++{
++    T *val;
++    Q_COMPILER_MEMORY_BARRIER;
++    val = __atomic_exchange_n(&_q_value, newValue, __ATOMIC_RELAXED);
++    Q_COMPILER_MEMORY_BARRIER;
++    return val;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndAddRelaxed(qptrdiff valueToAdd)
++{
++    T *val;
++    Q_COMPILER_MEMORY_BARRIER;
++    val = __atomic_fetch_add(&_q_value, valueToAdd, __ATOMIC_RELAXED);
++    Q_COMPILER_MEMORY_BARRIER;
++    return val;
++}
++
++inline bool QBasicAtomicInt::testAndSetAcquire(int expectedValue, int newValue)
++{
++    bool returnValue = testAndSetRelaxed(expectedValue, newValue);
++    Q_DATA_MEMORY_BARRIER;
++    return returnValue;
++}
++
++inline bool QBasicAtomicInt::testAndSetRelease(int expectedValue, int newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    return testAndSetRelaxed(expectedValue, newValue);
++}
++
++inline bool QBasicAtomicInt::testAndSetOrdered(int expectedValue, int newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    bool returnValue = testAndSetRelaxed(expectedValue, newValue);
++    Q_COMPILER_MEMORY_BARRIER;
++    return returnValue;
++}
++
++inline int QBasicAtomicInt::fetchAndStoreAcquire(int newValue)
++{
++    int returnValue = fetchAndStoreRelaxed(newValue);
++    Q_DATA_MEMORY_BARRIER;
++    return returnValue;
++}
++
++inline int QBasicAtomicInt::fetchAndStoreRelease(int newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    return fetchAndStoreRelaxed(newValue);
++}
++
++inline int QBasicAtomicInt::fetchAndStoreOrdered(int newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    int returnValue = fetchAndStoreRelaxed(newValue);
++    Q_COMPILER_MEMORY_BARRIER;
++    return returnValue;
++}
++
++inline int QBasicAtomicInt::fetchAndAddAcquire(int valueToAdd)
++{
++    int returnValue = fetchAndAddRelaxed(valueToAdd);
++    Q_DATA_MEMORY_BARRIER;
++    return returnValue;
++}
++
++inline int QBasicAtomicInt::fetchAndAddRelease(int valueToAdd)
++{
++    Q_DATA_MEMORY_BARRIER;
++    return fetchAndAddRelaxed(valueToAdd);
++}
++
++inline int QBasicAtomicInt::fetchAndAddOrdered(int valueToAdd)
++{
++    Q_DATA_MEMORY_BARRIER;
++    int returnValue = fetchAndAddRelaxed(valueToAdd);
++    Q_COMPILER_MEMORY_BARRIER;
++    return returnValue;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::testAndSetAcquire(T *expectedValue, T *newValue)
++{
++    bool returnValue = testAndSetRelaxed(expectedValue, newValue);
++    Q_DATA_MEMORY_BARRIER;
++    return returnValue;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::testAndSetRelease(T *expectedValue, T *newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    return testAndSetRelaxed(expectedValue, newValue);
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE bool QBasicAtomicPointer<T>::testAndSetOrdered(T *expectedValue, T *newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    bool returnValue = testAndSetAcquire(expectedValue, newValue);
++    Q_COMPILER_MEMORY_BARRIER;
++    return returnValue;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndStoreAcquire(T *newValue)
++{
++    T *returnValue = fetchAndStoreRelaxed(newValue);
++    Q_DATA_MEMORY_BARRIER;
++    return returnValue;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndStoreRelease(T *newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    return fetchAndStoreRelaxed(newValue);
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndStoreOrdered(T *newValue)
++{
++    Q_DATA_MEMORY_BARRIER;
++    T *returnValue = fetchAndStoreRelaxed(newValue);
++    Q_COMPILER_MEMORY_BARRIER;
++    return returnValue;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndAddAcquire(qptrdiff valueToAdd)
++{
++    T *returnValue = fetchAndAddRelaxed(valueToAdd);
++    Q_DATA_MEMORY_BARRIER;
++    return returnValue;
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndAddRelease(qptrdiff valueToAdd)
++{
++    Q_DATA_MEMORY_BARRIER;
++    return fetchAndAddRelaxed(valueToAdd);
++}
++
++template <typename T>
++Q_INLINE_TEMPLATE T *QBasicAtomicPointer<T>::fetchAndAddOrdered(qptrdiff valueToAdd)
++{
++    Q_DATA_MEMORY_BARRIER;
++    T *returnValue = fetchAndAddRelaxed(valueToAdd);
++    Q_COMPILER_MEMORY_BARRIER;
++    return returnValue;
++}
++
++#undef Q_DATA_MEMORY_BARRIER
++#undef Q_COMPILER_MEMORY_BARRIER
++
++QT_END_NAMESPACE
++
++QT_END_HEADER
++
++#endif // QATOMIC_AARCH64_H
+diff -up qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_arch.h.aarch64 qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_arch.h
+--- qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_arch.h.aarch64	2015-05-07 09:14:48.000000000 -0500
++++ qt-everywhere-opensource-src-4.8.7/src/corelib/arch/qatomic_arch.h	2015-05-08 21:48:33.271061031 -0500
+@@ -94,6 +94,8 @@ QT_BEGIN_HEADER
+ #  include "QtCore/qatomic_sh4a.h"
+ #elif defined(QT_ARCH_NACL)
+ #  include "QtCore/qatomic_generic.h"
++#elif defined(QT_ARCH_AARCH64)
++#  include "QtCore/qatomic_aarch64.h"
+ #else
+ #  error "Qt has not been ported to this architecture"
+ #endif


### PR DESCRIPTION
The KDE Platform/Sdk will probably provide Qt5.

However some apps are still stuck with Qt4, so they will need to bundle
it.

Given how complicated it was to get it building, this seems like a good
thing to share.

Most of the optional features are disabled though, especially WebKit. If
those are needed, please use a new JSON manifest.

The Aarch64 patch comes from the Fedora package.