### PR TITLE
Fix warning in udev manifest

### DIFF
--- a/udev/udev-175.json
+++ b/udev/udev-175.json
@@ -29,7 +29,7 @@
     },
     {
       "type": "script",
-      "name": "autogen.sh",
+      "dest-filename": "autogen.sh",
       "commands": [
         "autoreconf -vfi"
       ]


### PR DESCRIPTION
Use "dest-filename" instead of "name" for script source