### PR TITLE
Import a patch from Fedora to fix HiDPi with QT5

### DIFF
--- a/qt5/qt5-qtbase.json
+++ b/qt5/qt5-qtbase.json
@@ -58,6 +58,10 @@
         "./configure.qt $processed"
       ],
       "dest-filename": "configure"
+    },
+    {
+      "type": "patch",
+      "path": "qtbase-hidpi_scale_at_192.patch"
     }
   ]
 }

--- a/qt5/qtbase-hidpi_scale_at_192.patch
+++ b/qt5/qtbase-hidpi_scale_at_192.patch
@@ -1,0 +1,13 @@
+diff --git a/src/plugins/platforms/xcb/qxcbscreen.cpp b/src/plugins/platforms/xcb/qxcbscreen.cpp
+index 5e136b5..0ad2842 100644
+--- a/src/plugins/platforms/xcb/qxcbscreen.cpp
++++ b/src/plugins/platforms/xcb/qxcbscreen.cpp
+@@ -620,7 +620,7 @@ void QXcbScreen::updateGeometry(const QRect &geom, uint8_t rotation)
+         m_sizeMillimeters = sizeInMillimeters(xGeometry.size(), virtualDpi());
+
+     qreal dpi = xGeometry.width() / physicalSize().width() * qreal(25.4);
+-    m_pixelDensity = qMax(1, qRound(dpi/96));
++    m_pixelDensity = qMax(1, (int) (dpi/96)); // instead of rounding at 1.5, round at 2.0 (same as GNOME)
+     m_geometry = QRect(xGeometry.topLeft(), xGeometry.size());
+     m_availableGeometry = xGeometry & m_virtualDesktop->workArea();
+     QWindowSystemInterface::handleScreenGeometryChange(QPlatformScreen::screen(), m_geometry, m_availableGeometry);


### PR DESCRIPTION
This is a pre-requisite to get e.g. VLC working correctly under HiDpi.