### PR TITLE
Add boost, gtk2 and libpng

### DIFF
--- a/boost/boost-configure.sh
+++ b/boost/boost-configure.sh
@@ -1,0 +1,11 @@
+
+./bootstrap.sh "$@"
+
+
+cat <<EOF >Makefile
+all:
+	./b2 -j `nproc`
+
+install:
+	./b2 install
+EOF

--- a/boost/boost.json
+++ b/boost/boost.json
@@ -1,0 +1,17 @@
+{
+    "name": "boost",
+    "buildsystem": "autotools",
+    "cleanup": [ "/lib/libboost_*.a", "/include/boost" ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz",
+            "sha256": "0445c22a5ef3bd69f5dfb48354978421a85ab395254a26b1ffb0aa1bfd63a108"
+        },
+        {
+            "type": "file",
+            "path": "boost-configure.sh",
+            "dest-filename": "configure"
+        }
+    ]
+}

--- a/gtk2/gnome-themes-standard.json
+++ b/gtk2/gnome-themes-standard.json
@@ -1,0 +1,16 @@
+{
+    "name": "gnome-themes-standard",
+    "config-opts": ["--disable-gtk3-engine"],
+    "cleanup": [
+        "/share/themes/Adwaita/gtk-3.0",
+        "/share/themes/Adwaita-dark/gtk-3.0",
+        "/share/themes/HighContrast/gtk-3.0"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.gnome.org/sources/gnome-themes-standard/3.22/gnome-themes-standard-3.22.3.tar.xz",
+            "sha256": "61dc87c52261cfd5b94d65e8ffd923ddeb5d3944562f84942eeeb197ab8ab56a"
+        }
+    ]
+}

--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -1,0 +1,23 @@
+{
+    "name": "gtk2",
+    "cleanup": [
+        "/bin",
+        "/share/gtk-2.0",
+        "/lib/gtk-2.0/include",
+        "/include"
+    ],
+    "config-opts": [
+        "--disable-gtk-doc",
+        "--disable-introspection",
+        "--disable-man",
+        "--disable-static",
+        "--with-xinput=xfree"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+        "url": "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.30.tar.xz",
+            "sha256": "0d15cec3b6d55c60eac205b1f3ba81a1ed4eadd9d0f8e7c508bc7065d0c4ca50"
+        }
+    ]
+}

--- a/libpng/libpng12.json
+++ b/libpng/libpng12.json
@@ -1,0 +1,16 @@
+{
+    "name": "libpng",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://razaoinfo.dl.sourceforge.net/project/libpng/libpng12/1.2.59/libpng-1.2.59.tar.gz",
+            "sha256": "4bd4b5ce04ce634c281ae76174714fa02b053b573ac2181c985db06aa57e1e9e"
+        }
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.la",
+        "/lib/*.a"
+    ]
+}


### PR DESCRIPTION
Boost or GTK2 is already used by many apps available from flathub. I think it's a good idea to provide them as reusable shared modules.
And libpng12 is needed by some proprietary apps like WPS.