### PR TITLE
Add pygame 1.9.3 and dependencies

### DIFF
--- a/pygame/audiofile-gcc6.patch
+++ b/pygame/audiofile-gcc6.patch
@@ -1,0 +1,21 @@
+From b62c902dd258125cac86cd2df21fc898035a43d3 Mon Sep 17 00:00:00 2001
+From: Michael Pruett <michael@68k.org>
+Date: Mon, 29 Aug 2016 23:08:26 -0500
+Subject: [PATCH] Fix undefined behavior in sign conversion.
+Origin: https://github.com/mpruett/audiofile/commit/b62c902dd258125cac86cd2df21fc898035a43d3
+
+---
+diff --git a/libaudiofile/modules/SimpleModule.h b/libaudiofile/modules/SimpleModule.h
+index 03c6c69..bad85ad 100644
+--- a/libaudiofile/modules/SimpleModule.h
++++ b/libaudiofile/modules/SimpleModule.h
+@@ -123,7 +123,8 @@ struct signConverter
+ 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
+ 
+ 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
+-	static const int kMinSignedValue = -1 << kScaleBits;
++	static const int kMaxSignedValue = (((1 << (kScaleBits - 1)) - 1) << 1) + 1;
++	static const int kMinSignedValue = -kMaxSignedValue - 1;
+ 
+ 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
+ 	{

--- a/pygame/fluidsynth-no-rawmidi.patch
+++ b/pygame/fluidsynth-no-rawmidi.patch
@@ -1,0 +1,69 @@
+diff -rupN fluidsynth-1.1.6.orig/src/drivers/fluid_alsa.c fluidsynth-1.1.6/src/drivers/fluid_alsa.c
+--- fluidsynth-1.1.6.orig/src/drivers/fluid_alsa.c	2012-08-16 05:01:13.000000000 +0100
++++ fluidsynth-1.1.6/src/drivers/fluid_alsa.c	2017-02-28 21:26:57.033244239 +0000
+@@ -96,7 +96,7 @@ struct fluid_alsa_formats_t fluid_alsa_f
+ };
+ 
+ 
+-
++#if 0
+ /*
+  * fluid_alsa_rawmidi_driver_t
+  *
+@@ -119,7 +119,7 @@ fluid_midi_driver_t* new_fluid_alsa_rawm
+ 
+ int delete_fluid_alsa_rawmidi_driver(fluid_midi_driver_t* p);
+ static void fluid_alsa_midi_run(void* d);
+-
++#endif
+ 
+ /*
+  * fluid_alsa_seq_driver_t
+@@ -535,7 +535,7 @@ static void fluid_alsa_audio_run_s16 (vo
+  *
+  */
+ 
+-
++#if 0
+ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t* settings)
+ {
+   fluid_settings_register_str(settings, "midi.alsa.device", "default", 0, NULL, NULL);
+@@ -698,7 +698,7 @@ fluid_alsa_midi_run(void* d)
+     }
+   }
+ }
+-
++#endif
+ /**************************************************************
+  *
+  *        Alsa sequencer
+diff -rupN fluidsynth-1.1.6.orig/src/drivers/fluid_mdriver.c fluidsynth-1.1.6/src/drivers/fluid_mdriver.c
+--- fluidsynth-1.1.6.orig/src/drivers/fluid_mdriver.c	2012-08-16 05:01:13.000000000 +0100
++++ fluidsynth-1.1.6/src/drivers/fluid_mdriver.c	2017-02-28 21:24:43.887833321 +0000
+@@ -24,11 +24,13 @@
+ 
+ /* ALSA */
+ #if ALSA_SUPPORT
++#if 0
+ fluid_midi_driver_t* new_fluid_alsa_rawmidi_driver(fluid_settings_t* settings,
+ 						 handle_midi_event_func_t handler,
+ 						 void* event_handler_data);
+ int delete_fluid_alsa_rawmidi_driver(fluid_midi_driver_t* p);
+ void fluid_alsa_rawmidi_driver_settings(fluid_settings_t* settings);
++#endif
+ 
+ fluid_midi_driver_t* new_fluid_alsa_seq_driver(fluid_settings_t* settings,
+ 					     handle_midi_event_func_t handler,
+@@ -109,10 +111,12 @@ struct fluid_mdriver_definition_t fluid_
+     fluid_oss_midi_driver_settings },
+ #endif
+ #if ALSA_SUPPORT
++#if 0
+   { "alsa_raw",
+     new_fluid_alsa_rawmidi_driver,
+     delete_fluid_alsa_rawmidi_driver,
+     fluid_alsa_rawmidi_driver_settings },
++#endif
+   { "alsa_seq",
+     new_fluid_alsa_seq_driver,
+     delete_fluid_alsa_seq_driver,

--- a/pygame/portmidi-no-java.patch
+++ b/pygame/portmidi-no-java.patch
@@ -1,0 +1,105 @@
+diff -rupN portmidi.orig/CMakeLists.txt portmidi/CMakeLists.txt
+--- portmidi.orig/CMakeLists.txt	2010-09-20 15:57:48.000000000 +0100
++++ portmidi/CMakeLists.txt	2017-03-03 13:50:58.494561245 +0000
+@@ -71,7 +71,3 @@ add_subdirectory(pm_common)
+ add_subdirectory(pm_test)
+ 
+ add_subdirectory(pm_dylib)
+-
+-# Cannot figure out how to make an xcode Java application with CMake
+-add_subdirectory(pm_java)
+-
+diff -rupN portmidi.orig/pm_common/CMakeLists.txt portmidi/pm_common/CMakeLists.txt
+--- portmidi.orig/pm_common/CMakeLists.txt	2010-09-20 15:57:48.000000000 +0100
++++ portmidi/pm_common/CMakeLists.txt	2017-03-03 14:02:32.851938051 +0000
+@@ -67,14 +67,6 @@ if(UNIX)
+     message(STATUS "SYSROOT: " ${CMAKE_OSX_SYSROOT})
+   else(APPLE)
+     # LINUX settings...
+-    include(FindJNI)
+-    message(STATUS "JAVA_JVM_LIB_PATH is " ${JAVA_JVM_LIB_PATH})
+-    message(STATUS "JAVA_INCLUDE_PATH is " ${JAVA_INCLUDE_PATH})
+-    message(STATUS "JAVA_INCLUDE_PATH2 is " ${JAVA_INCLUDE_PATH2})
+-    message(STATUS "JAVA_JVM_LIBRARY is " ${JAVA_JVM_LIBRARY})
+-    set(JAVA_INCLUDE_PATHS ${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH2})
+-    # libjvm.so is found relative to JAVA_INCLUDE_PATH:
+-    set(JAVAVM_LIB ${JAVA_JVM_LIBRARY}/libjvm.so)
+ 
+     set(LINUXSRC pmlinuxalsa pmlinux finddefault)
+     prepend_path(LIBSRC ../pm_linux/ ${LINUXSRC})
+@@ -99,7 +91,6 @@ else(UNIX)
+     set(PM_NEEDED_LIBS winmm.lib)
+   endif(WIN32)
+ endif(UNIX)
+-set(JNI_EXTRA_LIBS ${PM_NEEDED_LIBS} ${JAVA_JVM_LIBRARY})
+ 
+ # this completes the list of library sources by adding shared code
+ list(APPEND LIBSRC pmutil portmidi)
+@@ -109,19 +100,11 @@ add_library(portmidi-static ${LIBSRC})
+ set_target_properties(portmidi-static PROPERTIES OUTPUT_NAME "portmidi_s")
+ target_link_libraries(portmidi-static ${PM_NEEDED_LIBS})
+ 
+-# define the jni library
+-include_directories(${JAVA_INCLUDE_PATHS})
+-
+-set(JNISRC ${LIBSRC} ../pm_java/pmjni/pmjni.c)
+-add_library(pmjni SHARED ${JNISRC})
+-target_link_libraries(pmjni ${JNI_EXTRA_LIBS})
+-set_target_properties(pmjni PROPERTIES EXECUTABLE_EXTENSION "jnilib")
+-
+ # install the libraries (Linux and Mac OS X command line)
+ if(UNIX)
+-  INSTALL(TARGETS portmidi-static pmjni
+-    LIBRARY DESTINATION /usr/local/lib
+-    ARCHIVE DESTINATION /usr/local/lib)
++  INSTALL(TARGETS portmidi-static
++    LIBRARY DESTINATION /app/lib
++    ARCHIVE DESTINATION /app/lib)
+ # .h files installed by pm_dylib/CMakeLists.txt, so don't need them here
+ #  INSTALL(FILES portmidi.h ../porttime/porttime.h
+ #    DESTINATION /usr/local/include)
+diff -rupN portmidi.orig/pm_dylib/CMakeLists.txt portmidi/pm_dylib/CMakeLists.txt
+--- portmidi.orig/pm_dylib/CMakeLists.txt	2009-11-20 00:41:10.000000000 +0000
++++ portmidi/pm_dylib/CMakeLists.txt	2017-03-03 14:03:56.807104521 +0000
+@@ -63,7 +63,6 @@ if(UNIX)
+     message(STATUS "SYSROOT: " ${CMAKE_OSX_SYSROOT})
+   else(APPLE)
+     # LINUX settings...
+-    include(FindJNI)
+     # message(STATUS "JAVA_JVM_LIB_PATH is " ${JAVA_JVM_LIB_PATH})
+     # message(STATUS "JAVA_INCLUDE_PATH is " ${JAVA_INCLUDE_PATH})
+     # note: should use JAVA_JVM_LIB_PATH, but it is not set properly
+@@ -75,12 +74,7 @@ if(UNIX)
+     # JAVA_INCLUDE_PATH2; if no, then we need to make both JAVA_INCLUDE_PATH
+     # and JAVA_INCLUDE_PATH2 set by user (will need clear documentation
+     # because JAVA_INCLUDE_PATH2 is pretty obscure)
+-    set(JAVA_INCLUDE_PATH  ${JAVA_INCLUDE_PATH-UNKNOWN}
+-        CACHE STRING "where to find Java SDK include directory")
+-    set(JAVA_INCLUDE_PATHS ${JAVA_INCLUDE_PATH} ${JAVA_INCLUDE_PATH}/linux)
+-    # libjvm.so is found relative to JAVA_INCLUDE_PATH:
+-    set(JAVAVM_LIB ${JAVA_INCLUDE_PATH}/../jre/lib/i386/client/libjvm.so)
+-
++    
+     set(LINUXSRC pmlinuxalsa pmlinux finddefault)
+     prepend_path(LIBSRC ../pm_linux/ ${LINUXSRC})
+     list(APPEND LIBSRC ../porttime/ptlinux)
+@@ -106,7 +100,6 @@ else(UNIX)
+     # message(STATUS "JAVAVM_LIB: " ${JAVAVM_LIB})
+   endif(WIN32)
+ endif(UNIX)
+-set(JNI_EXTRA_LIBS ${PM_NEEDED_LIBS} ${JAVAVM_LIB})
+ 
+ # this completes the list of library sources by adding shared code
+ set(SHARED_FILES pmutil portmidi)
+@@ -120,8 +113,8 @@ target_link_libraries(portmidi-dynamic $
+ # install the libraries (Linux and Mac OS X command line)
+ if(UNIX)
+   INSTALL(TARGETS portmidi-dynamic
+-    LIBRARY DESTINATION /usr/local/lib
+-    ARCHIVE DESTINATION /usr/local/lib)
++    LIBRARY DESTINATION /app/lib
++    ARCHIVE DESTINATION /app/lib)
+   INSTALL(FILES ../pm_common/portmidi.h ../porttime/porttime.h
+-    DESTINATION /usr/local/include)
++    DESTINATION /app/include)
+ endif(UNIX)

--- a/pygame/pygame-1.9.3.json
+++ b/pygame/pygame-1.9.3.json
@@ -1,0 +1,90 @@
+{
+    "name": "pygame",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://pypi.python.org/packages/61/06/3c25051549c252cc6fde01c8aeae90b96831370884504fe428a623316def/pygame-1.9.3.tar.gz",
+            "sha256": "751021819bdc0cbe5cbd51904abb6ff9e9aee5b0e8955af02284d0e77d6c9ec2"
+        },
+        {
+            "type": "patch",
+            "path": "pygame-add-search-dirs.patch"
+        }
+    ],
+    "buildsystem": "simple",
+    "build-commands": [
+      "/usr/bin/pip3 install --ignore-installed --no-deps --prefix=/app ."
+    ],
+    "build-options": {
+      "env": {
+        "PORTMIDI_INC_PORTTIME": "1",
+        "LOCALBASE": "/app"
+      }
+    },
+    "modules": [
+        "../SDL/SDL-1.2.15.json",
+        "../SDL/SDL_image-1.2.12.json",
+        "../SDL/SDL_ttf-2.0.11.json",
+        "../smpeg/smpeg-0.4.5.json",
+        "../SDL/SDL_mixer-1.2.12.json",
+        {
+            "name": "audiofile",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://audiofile.68k.org/audiofile-0.3.6.tar.gz",
+                    "sha256": "cdc60df19ab08bfe55344395739bb08f50fc15c92da3962fac334d3bff116965"
+                },
+                {
+                    "type": "patch",
+                    "path": "audiofile-gcc6.patch"
+                }
+            ]
+        },
+        {
+            "name": "libmikmod",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://sourceforge.net/projects/mikmod/files/libmikmod/3.3.11.1/libmikmod-3.3.11.1.tar.gz",
+                    "sha256": "ad9d64dfc8f83684876419ea7cd4ff4a41d8bcd8c23ef37ecb3a200a16b46d19"
+                }
+            ]
+        },
+        {
+            "name": "fluidsynth",    
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/fluidsynth/fluidsynth-1.1.6/fluidsynth-1.1.6.tar.bz2",
+                    "sha256": "d28b47dfbf7f8e426902ae7fa2981d821fbf84f41da9e1b85be933d2d748f601"
+                },
+                {
+                    "type": "patch",
+                    "path": "fluidsynth-no-rawmidi.patch"
+                }
+            ]
+        },
+        {
+            "name": "portmidi",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+              "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY:STRING=/app/lib",
+              "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:STRING=/app/lib",
+              "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY:STRING=/app/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip",
+                    "sha256": "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
+                },
+                {
+                    "type": "patch",
+                    "path": "portmidi-no-java.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/pygame/pygame-1.9.3.json
+++ b/pygame/pygame-1.9.3.json
@@ -13,7 +13,7 @@
     ],
     "buildsystem": "simple",
     "build-commands": [
-      "/usr/bin/pip3 install --ignore-installed --no-deps --prefix=/app ."
+      "pip3 install --ignore-installed --no-deps --prefix=/app ."
     ],
     "build-options": {
       "env": {

--- a/pygame/pygame-1.9.3.json
+++ b/pygame/pygame-1.9.3.json
@@ -54,6 +54,9 @@
         {
             "name": "fluidsynth",    
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+              "-DCMAKE_BUILD_TYPE=Release"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -70,6 +73,7 @@
             "name": "portmidi",
             "buildsystem": "cmake-ninja",
             "config-opts": [
+              "-DCMAKE_BUILD_TYPE=Release",
               "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY:STRING=/app/lib",
               "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:STRING=/app/lib",
               "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY:STRING=/app/bin"

--- a/pygame/pygame-add-search-dirs.patch
+++ b/pygame/pygame-add-search-dirs.patch
@@ -1,0 +1,27 @@
+diff -r 407caa445ee0 config_unix.py
+--- a/config_unix.py	Mon Jan 16 21:12:10 2017 +0000
++++ b/config_unix.py	Fri Mar 03 15:10:07 2017 +0000
+@@ -110,6 +110,12 @@
+             self.found = 1
+         else:
+             print (self.name + '        '[len(self.name):] + ': not found')
++            print('incname',  incname)
++            print('incdirs', incdirs)
++            print('self.inc_dir', self.inc_dir)
++            print('libnames', libnames)
++            print('libdirs', libdirs)
++            print('self.lib_dir', self.lib_dir)
+ 
+ 
+ class DependencyPython:
+@@ -195,8 +201,8 @@
+     incdirs += ["/usr/local"+d for d in origincdirs]
+     libdirs += ["/usr/local"+d for d in origlibdirs]
+     if localbase:
+-        incdirs = [localbase+d for d in origincdirs]
+-        libdirs = [localbase+d for d in origlibdirs]
++        incdirs += [localbase+d for d in origincdirs]
++        libdirs += [localbase+d for d in origlibdirs]
+ 
+     for arg in DEPS[0].cflags.split():
+         if arg[:2] == '-I':


### PR DESCRIPTION
This follows from [my other pull request](https://github.com/flathub/flathub/pull/424) where I tried to make a pygame baseapp, but I was told that it was more appropriate as a shared module. So, here it is. :-)

I've currently left four new dependencies of pygame as internal modules, but I'm happy to split these out as separate modules if that's better. These are audiofile, libmikmod, fluidsynth and portmidi.