### PR TITLE
Update archive download link

### DIFF
--- a/qt4/qt4-4.8.7-minimal.json
+++ b/qt4/qt4-4.8.7-minimal.json
@@ -65,7 +65,7 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz",
+            "url": "https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz",
             "sha256": "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
         },
         {


### PR DESCRIPTION
The download link for the Qt4 archive has been removed from https://download.qt.io/official_releases/qt/, so attempting to download the archive in its current state will result in a 404 error.