### PR TITLE
SDL_Mixer: fixed configure failing when smpeg isn't installed

### DIFF
--- a/SDL/SDL_mixer-1.2.12.json
+++ b/SDL/SDL_mixer-1.2.12.json
@@ -12,7 +12,9 @@
             "type": "script",
             "dest-filename": "autogen.sh",
             "commands": [
-                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi",
+                "rm acinclude/libtool.m4",
+                "rm acinclude/lt*",
+                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi -I acinclude",
                 "cp -p /usr/share/automake-*/config.{sub,guess} build-scripts"
             ]
         }


### PR DESCRIPTION
This adds the `acinclude/` to `autoconf` and thus fixes the configure of SDL_Mixer failing when the smpeg isn't installed:

```
checking signal.h usability... yes
checking signal.h presence... yes
checking for signal.h... yes
checking for setbuf... yes
./configure: line 13698: syntax error near unexpected token `$SMPEG_VERSION,'
./configure: line 13698: `    AM_PATH_SMPEG($SMPEG_VERSION, have_smpeg=yes, have_smpeg=no)'
Error: module SDL_mixer: Child process exited with code 2
```

libtools files in `acinclude/` are removed due to being to old and  causing build failure:

```
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from libtool 2.2.6.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
```
