### PR TITLE
udev: fix exec_prefix

### DIFF
--- a/udev/udev-175.json
+++ b/udev/udev-175.json
@@ -37,5 +37,8 @@
         "autoreconf -vfi"
       ]
     }
+  ],
+  "post-install": [
+    "sed -i 's|${exec_prefix}|/app|g' /app/share/pkgconfig/udev.pc"
   ]
 }


### PR DESCRIPTION
I had to apply this change to make udev work with bluez, see also https://github.com/flathub/shared-modules/issues/8 and https://github.com/flathub/org.subsurface_divelog.Subsurface/blob/master/org.subsurface_divelog.Subsurface.yaml#L101