### PR TITLE
Add python2 shared module

### DIFF
--- a/python2.7/python-2.7.15.json
+++ b/python2.7/python-2.7.15.json
@@ -1,0 +1,42 @@
+{
+    "name": "python-2.7",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz",
+            "sha256": "18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db"
+        }
+    ],
+    "config-opts": [
+        "--enable-shared",
+        "--with-ensurepip=yes",
+        "--with-system-expat",
+        "--with-system-ffi",
+        "--enable-loadable-sqlite-extensions",
+        "--with-dbmliborder=gdbm",
+        "--enable-unicode=ucs4"
+    ],
+    "cleanup": [
+        "/bin/2to3*",
+        "/bin/easy_install*",
+        "/bin/idle*",
+        "/bin/pyvenv*",
+        "/bin/pydoc*",
+        "/include",
+        "/share",
+
+        /* Test scripts */
+        "/lib/python*/test",
+        "/lib/python*/*/test",
+        "/lib/python*/*/tests",
+        "/lib/python*/lib-tk/test",
+        "/lib/python*/lib-dynload/_*_test.*.so",
+        "/lib/python*/lib-dynload/_test*.*.so",
+
+        /* Unused modules */
+        "/lib/python*/idlelib",
+        "/lib/python*/tkinter*",
+        "/lib/python*/turtle*",
+        "/lib/python*/lib2to3*"
+    ]
+}


### PR DESCRIPTION
`org.freedesktop.Platform` has dropped `python 2` but steam just started depending on it for some reason.

I copied the cleanup stuff from [here][2] and the fd.o 18.08 python2 [cleanups][3]

[2]: https://github.com/flatpak/freedesktop-sdk-base/issues/20#issuecomment-375896426
[3]: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/blob/05d273306abb0225d2d2905c7bdd8de519d87066/elements/base/python2.bst#L40-55