### PR TITLE
Python2: Fix libpython2.7.so.1.0 permissions

### DIFF
--- a/python2.7/python-2.7.15.json
+++ b/python2.7/python-2.7.15.json
@@ -16,6 +16,10 @@
         "--with-dbmliborder=gdbm",
         "--enable-unicode=ucs4"
     ],
+    "post-install": [
+        /* Theres seem to be a permissions missmatch that causes the debug stripping to fail */
+        "chmod 644 /app/lib/libpython2.7.so.1.0"
+    ],
     "cleanup": [
         "/bin/2to3*",
         "/bin/easy_install*",


### PR DESCRIPTION
While trying to build Steam, flatpak fails to strip
libpython2.7.so.1.0 due to libpython2.7 being installed as read-only.

Related log: https://flathub.org/builds/#/builders/2/builds/3780