### PR TITLE
udev: Do not disable gudev

### DIFF
--- a/udev/udev-175.json
+++ b/udev/udev-175.json
@@ -4,7 +4,6 @@
   "config-opts": [
     "--disable-hwdb",
     "--disable-logging",
-    "--disable-gudev",
     "--disable-introspection",
     "--disable-keymap",
     "--disable-mtd_probe"


### PR DESCRIPTION
GUdev is used by fwupd, gimp, gnome-software, shotwell, rhythmbox, gnome-boxes,
and lots of other system deps. It adds a few ms to the build time of the shared
module and allows other manifests to just use the shared module rather than
building a custom udev 175 themselves.