### PR TITLE
Fix lame with Freedesktop runtime 18.08

### DIFF
--- a/lame/lame-3.99.5.json
+++ b/lame/lame-3.99.5.json
@@ -21,6 +21,11 @@
       "path": "lame-ansi2knr2devnull.patch"
     },
     {
+      "type": "patch",
+      "path": "lame-tinfo.patch",
+      "strip-components": 0
+    },
+    {
       "type": "script",
       "dest-filename": "autogen.sh",
       "commands": [

--- a/lame/lame-tinfo.patch
+++ b/lame/lame-tinfo.patch
@@ -1,0 +1,23 @@
+initscr is not used anywhere in lame sourcetree, check for used tgetent instead
+check for separate tinfo library optionally built out from libncurses source tree,
+like used in debian and gentoo
+- ssuominen@g.o
+
+http://bugs.gentoo.org/454322
+
+--- configure.in
++++ configure.in
+@@ -372,9 +372,10 @@
+ 
+ AC_CHECK_HEADERS(termcap.h)
+ AC_CHECK_HEADERS(ncurses/termcap.h)
+-AC_CHECK_LIB(termcap, initscr, HAVE_TERMCAP="termcap")
+-AC_CHECK_LIB(curses, initscr, HAVE_TERMCAP="curses")
+-AC_CHECK_LIB(ncurses, initscr, HAVE_TERMCAP="ncurses")
++AC_CHECK_LIB(termcap, tgetent, HAVE_TERMCAP="termcap")
++AC_CHECK_LIB(curses, tgetent, HAVE_TERMCAP="curses")
++AC_CHECK_LIB(ncurses, tgetent, HAVE_TERMCAP="ncurses")
++AC_CHECK_LIB(tinfo, tgetent, HAVE_TERMCAP="tinfo")
+ 
+ AM_ICONV
+  


### PR DESCRIPTION
The compilation did fail.
Patch from Gentoo.