### PR TITLE
Add dbus-glib module

### DIFF
--- a/dbus-glib/dbus-glib-0.110.json
+++ b/dbus-glib/dbus-glib-0.110.json
@@ -1,0 +1,23 @@
+{
+    "name": "dbus-glib",
+    "cleanup": [
+        "*.la",
+        "/bin",
+        "/etc",
+        "/include",
+        "/libexec",
+        "/share/gtk-doc",
+        "/share/man"
+    ],
+    "config-opts": [
+        "--disable-static",
+        "--disable-gtk-doc"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.110.tar.gz",
+            "sha256": "7ce4760cf66c69148f6bd6c92feaabb8812dee30846b24cd0f7395c436d7e825"
+        }
+    ]
+}


### PR DESCRIPTION
Based on the block in @ramcq's Tomboy manifest at https://github.com/flathub/flathub/pull/722, reformatted to YAML for legibility and updated to dbus-glib 0.110.

dbus-glib appears in 5 existing apps on Flathub (not including Tomboy).