### PR TITLE
fix build for udev

### DIFF
--- a/udev/udev-175.json
+++ b/udev/udev-175.json
@@ -6,7 +6,8 @@
     "--disable-logging",
     "--disable-introspection",
     "--disable-keymap",
-    "--disable-mtd_probe"
+    "--disable-mtd_probe",
+    "--with-systemdsystemunitdir=/app/lib/systemd/"
   ],
   "cleanup": [
     "/include",
@@ -14,6 +15,7 @@
     "/libexec",
     "/sbin",
     "/lib/pkgconfig",
+    "/lib/systemd",
     "/man",
     "/share/aclocal",
     "/share/doc",


### PR DESCRIPTION
fixes the build by providing a sane path for systemd unit files. They will be deleted afterwards. It should work the same like before. I can't test it since udev does not work for me at all on ArchLinux.