### PR TITLE
SDL: Disable backing store by default

### DIFF
--- a/SDL/SDL-1.2.15.json
+++ b/SDL/SDL-1.2.15.json
@@ -22,6 +22,10 @@
             "path": "sdl-libx11-build.patch"
         },
         {
+            "type": "patch",
+            "path": "sdl-check-for-SDL_VIDEO_X11_BACKINGSTORE.patch"
+        },
+        {
             "type": "script",
             "dest-filename": "autogen.sh",
             "commands": [

--- a/SDL/sdl-check-for-SDL_VIDEO_X11_BACKINGSTORE.patch
+++ b/SDL/sdl-check-for-SDL_VIDEO_X11_BACKINGSTORE.patch
@@ -1,0 +1,24 @@
+Description: Do not harness backing store by default
+ xorg-server 1.15 enables backing store if composite extension is enabled
+ (default settings). Harnessing backing store through compositor leads to
+ tearing effect.
+ This patch reverts default harnessing backing store to conditional use if
+ SDL_VIDEO_X11_BACKINGSTORE environment variable exists.
+Origin: https://bugs.launchpad.net/ubuntu/+source/libsdl1.2/+bug/1280665/comments/1
+Bug: https://bugzilla.libsdl.org/show_bug.cgi?id=2383
+Bug-Debian: https://bugs.debian.org/747168
+
+--- a/src/video/x11/SDL_x11video.c
++++ b/src/video/x11/SDL_x11video.c
+@@ -1088,10 +1088,8 @@
+ 		}
+ 	}
+ 
+-#if 0 /* This is an experiment - are the graphics faster now? - nope. */
+ 	if ( SDL_getenv("SDL_VIDEO_X11_BACKINGSTORE") )
+-#endif
+-	/* Cache the window in the server, when possible */
++	/* Cache the window in the server when possible, on request */
+ 	{
+ 		Screen *xscreen;
+ 		XSetWindowAttributes a;


### PR DESCRIPTION
Use of a backing store causes tearing issues in composited environments,
so disable it by default (and allow it to be enabled by env var)

The patch is taken from debian packaging, but similar patches exist
on other distributions for this issue.

More information at:
https://bugs.launchpad.net/ubuntu/+source/libsdl1.2/+bug/1280665/comments/1
https://bugzilla.libsdl.org/show_bug.cgi?id=2383
https://bugs.debian.org/747168