### PR TITLE
Add gtkmm module

### DIFF
--- a/gtkmm/gtkmm.json
+++ b/gtkmm/gtkmm.json
@@ -1,0 +1,125 @@
+{
+    "name": "gtkmm",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.0.tar.xz",
+            "sha256": "cf5fc92805e581c8303e08d54519457ba07f15b766e9b1edde4862993ac1aa43"
+        }
+    ],
+    "config-opts": [
+        "--disable-documentation"
+    ],
+    "cleanup": [
+        "*.a",
+        "*.la",
+        "/include",
+        "/lib/gdkmm-3.0",
+        "/lib/gtkmm-3.0",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/aclocal",
+        "/share/man",
+        "/share/pkgconfig"
+    ],
+    "modules": [
+        {
+            "name": "sigc++",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.1.tar.xz",
+                    "sha256": "c9a25f26178c6cbb147f9904d8c533b5a5c5111a41ac2eb781eb734eea446003"
+                }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/sigc++-2.0",
+                "/lib/pkgconfig",
+                "/lib/sigc++-2.0"
+            ]
+        },
+        {
+            "name": "glibmm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.58/glibmm-2.58.1.tar.xz",
+                    "sha256": "6e5fe03bdf1e220eeffd543e017fd2fb15bcec9235f0ffd50674aff9362a85f0"
+                }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/glibmm-2.4",
+                "/include/giomm-2.4",
+                "/lib/glibmm-2.4",
+                "/lib/giomm-2.4",
+                "/lib/libglibmm_generate_extra_defs*",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "cairomm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
+                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
+                }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/cairomm-1.0",
+                "/lib/cairomm-1.0",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "pangomm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.42/pangomm-2.42.0.tar.xz",
+                    "sha256": "ca6da067ff93a6445780c0b4b226eb84f484ab104b8391fb744a45cbc7edbf56"
+                }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/pangomm-1.4",
+                "/lib/pangomm-1.4",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "atkmm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.28/atkmm-2.28.0.tar.xz",
+                    "sha256": "4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a"
+                }
+            ],
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "cleanup": [
+                "*.la",
+                "/include/atkmm-1.6",
+                "/lib/atkmm-1.6",
+                "/lib/pkgconfig"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
These are the latest stable versions at the time of writing. The rules
are derived from org.gnome.Gnote, which is one of 10 apps already on
Flathub which uses these libraries.

(Perhaps we should consider making an SDK extension for this?)