### PR TITLE
fix udev build

### DIFF
--- a/udev/sysmacros.patch
+++ b/udev/sysmacros.patch
@@ -1,0 +1,111 @@
+diff -Naur udev-175/extras/cdrom_id/cdrom_id.c udev-175-fix/extras/cdrom_id/cdrom_id.c
+--- udev-175/extras/cdrom_id/cdrom_id.c	2011-06-17 03:28:33.251601571 +0200
++++ udev-175-fix/extras/cdrom_id/cdrom_id.c	2019-04-02 12:24:40.131653700 +0200
+@@ -37,6 +37,7 @@
+ #include <sys/time.h>
+ #include <sys/ioctl.h>
+ #include <linux/cdrom.h>
++#include <sys/sysmacros.h>
+ 
+ #include "libudev.h"
+ #include "libudev-private.h"
+diff -Naur udev-175/extras/scsi_id/scsi_serial.c udev-175-fix/extras/scsi_id/scsi_serial.c
+--- udev-175/extras/scsi_id/scsi_serial.c	2011-04-15 00:14:23.739780499 +0200
++++ udev-175-fix/extras/scsi_id/scsi_serial.c	2019-04-02 12:24:18.781548109 +0200
+@@ -33,6 +33,7 @@
+ #include <scsi/sg.h>
+ #include <linux/types.h>
+ #include <linux/bsg.h>
++#include <sys/sysmacros.h>
+ 
+ #include "libudev.h"
+ #include "libudev-private.h"
+diff -Naur udev-175/libudev/libudev-device.c udev-175-fix/libudev/libudev-device.c
+--- udev-175/libudev/libudev-device.c	2011-09-23 14:43:44.305381687 +0200
++++ udev-175-fix/libudev/libudev-device.c	2019-04-02 12:19:17.220061349 +0200
+@@ -24,6 +24,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/socket.h>
+ #include <linux/sockios.h>
++#include <sys/sysmacros.h>
+ 
+ #include "libudev.h"
+ #include "libudev-private.h"
+diff -Naur udev-175/libudev/libudev-device-private.c udev-175-fix/libudev/libudev-device-private.c
+--- udev-175/libudev/libudev-device-private.c	2011-04-24 00:13:02.466797877 +0200
++++ udev-175-fix/libudev/libudev-device-private.c	2019-04-02 12:19:38.570166315 +0200
+@@ -18,6 +18,7 @@
+ #include <fcntl.h>
+ #include <string.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ 
+ #include "libudev.h"
+ #include "libudev-private.h"
+diff -Naur udev-175/libudev/libudev-enumerate.c udev-175-fix/libudev/libudev-enumerate.c
+--- udev-175/libudev/libudev-enumerate.c	2011-08-04 04:26:50.130004746 +0200
++++ udev-175-fix/libudev/libudev-enumerate.c	2019-04-02 12:23:07.947864764 +0200
+@@ -20,7 +20,7 @@
+ #include <stdbool.h>
+ #include <sys/stat.h>
+ #include <sys/param.h>
+-
++#include <sys/sysmacros.h>
+ #include "libudev.h"
+ #include "libudev-private.h"
+ 
+diff -Naur udev-175/udev/udevadm-info.c udev-175-fix/udev/udevadm-info.c
+--- udev-175/udev/udevadm-info.c	2011-10-09 22:49:21.817999569 +0200
++++ udev-175-fix/udev/udevadm-info.c	2019-04-02 12:25:44.908641018 +0200
+@@ -28,6 +28,7 @@
+ #include <fcntl.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ #include "udev.h"
+ 
+diff -Naur udev-175/udev/udevd.c udev-175-fix/udev/udevd.c
+--- udev-175/udev/udevd.c	2011-10-11 13:25:39.619713005 +0200
++++ udev-175-fix/udev/udevd.c	2019-04-02 12:17:59.529679774 +0200
+@@ -43,6 +43,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/inotify.h>
+ #include <sys/utsname.h>
++#include <sys/sysmacros.h>
+ 
+ #include "udev.h"
+ #include "sd-daemon.h"
+diff -Naur udev-175/udev/udev-event.c udev-175-fix/udev/udev-event.c
+--- udev-175/udev/udev-event.c	2011-10-06 00:58:11.372582876 +0200
++++ udev-175-fix/udev/udev-event.c	2019-04-02 12:18:11.513071921 +0200
+@@ -33,6 +33,7 @@
+ #include <sys/socket.h>
+ #include <sys/signalfd.h>
+ #include <linux/sockios.h>
++#include <sys/sysmacros.h>
+ 
+ #include "udev.h"
+ 
+diff -Naur udev-175/udev/udev-node.c udev-175-fix/udev/udev-node.c
+--- udev-175/udev/udev-node.c	2011-11-01 13:08:15.803635931 +0100
++++ udev-175-fix/udev/udev-node.c	2019-04-02 12:18:21.729788742 +0200
+@@ -28,6 +28,7 @@
+ #include <sys/time.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ 
+ #include "udev.h"
+ 
+diff -Naur udev-175/udev/udev-rules.c udev-175-fix/udev/udev-rules.c
+--- udev-175/udev/udev-rules.c	2011-10-22 21:17:06.587663679 +0200
++++ udev-175-fix/udev/udev-rules.c	2019-04-02 12:18:55.866623075 +0200
+@@ -29,6 +29,7 @@
+ #include <dirent.h>
+ #include <fnmatch.h>
+ #include <time.h>
++#include <sys/sysmacros.h>
+ 
+ #include "udev.h"
+ 

--- a/udev/udev-175.json
+++ b/udev/udev-175.json
@@ -32,6 +32,10 @@
       "sha256": "4c7937fe5a1521316ea571188745b9a00a9fdf314228cffc53a7ba9e5968b7ab"
     },
     {
+      "type": "patch",
+      "path": "sysmacros.patch"
+    },
+    {
       "type": "script",
       "dest-filename": "autogen.sh",
       "commands": [


### PR DESCRIPTION
Multiple files now need `#include <sys/sysmacros.h>`. Seems to work. Tried it with one game that needs udev.

Fixes https://github.com/flathub/shared-modules/issues/56