### PR TITLE
Scrape off 2 redirects (HTTP→HTTPS and .→www.) when pulling udev

### DIFF
--- a/udev/udev-175.json
+++ b/udev/udev-175.json
@@ -28,7 +28,7 @@
   "sources": [
     {
       "type": "archive",
-      "url": "http://kernel.org/pub/linux/utils/kernel/hotplug/udev-175.tar.bz2",
+      "url": "https://www.kernel.org/pub/linux/utils/kernel/hotplug/udev-175.tar.bz2",
       "sha256": "4c7937fe5a1521316ea571188745b9a00a9fdf314228cffc53a7ba9e5968b7ab"
     },
     {


### PR DESCRIPTION
Makes download a bit faster and avoids plain HTTP.