### PR TITLE
python2: Cleanup static library

### DIFF
--- a/python2.7/python-2.7.json
+++ b/python2.7/python-2.7.json
@@ -41,6 +41,9 @@
         "/lib/python*/idlelib",
         "/lib/python*/tkinter*",
         "/lib/python*/turtle*",
-        "/lib/python*/lib2to3*"
+        "/lib/python*/lib2to3*",
+        
+        /* Static library */
+        "/lib/python2.7/config/libpython2.7.a"
     ]
 }


### PR DESCRIPTION
This one weights 10MB and shouldn't be needed for anything. Providing shared libs is sufficient.