### PR TITLE
Use $FLATPAK_DEST in python-2.7's post-install

### DIFF
--- a/python2.7/python-2.7.json
+++ b/python2.7/python-2.7.json
@@ -18,7 +18,7 @@
     ],
     "post-install": [
         /* Theres seem to be a permissions missmatch that causes the debug stripping to fail */
-        "chmod 644 /app/lib/libpython2.7.so.1.0"
+        "chmod 644 $FLATPAK_DEST/lib/libpython2.7.so.1.0"
     ],
     "cleanup": [
         "/bin/2to3*",


### PR DESCRIPTION
This will allow sdk extensions and the like to use this module. (Also don't get scared off by the patch-1 branch name, I tested an identical change locally.)