### PR TITLE
Add intltool

### DIFF
--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -103,6 +103,7 @@
           "sha256": "4cf1e5ca4b067a3bed3cdfa658d49ac597d817b2de627a1095214565f862d034"
         }
       ]
-    }
+    },
+    "../intltool/intltool-0.51.json"
   ]
 }

--- a/intltool/intltool-0.51.json
+++ b/intltool/intltool-0.51.json
@@ -1,0 +1,11 @@
+{
+  "name": "intltool",
+  "cleanup": [ "*" ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+      "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+    }
+  ]
+}


### PR DESCRIPTION
Needed to build `gnome-themes-extra` with FD.o runtime 19.08. May be useful for other apps.
Fixes #66 