### PR TITLE
Build intltool before gnome-theme-extras

### DIFF
--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -32,6 +32,7 @@
     }
   ],
   "modules": [
+    "../intltool/intltool-0.51.json",
     {
       "name": "gtk2",
       "cleanup": [
@@ -103,7 +104,6 @@
           "sha256": "4b66c798dab093f0fa738e5c10688d395a463287d13678c208a81051af5d2429"
         }
       ]
-    },
-    "../intltool/intltool-0.51.json"
+    }
   ]
 }


### PR DESCRIPTION
gnome-theme-extras is the module that requires intltool. So it should be built before

See https://gitlab.gnome.org/GNOME/dia/commit/999f9bc44adff544e97ad8f3f945c7bbccfccc1f
