### PR TITLE
Add openjpeg

### DIFF
--- a/openjpeg/openjpeg.json
+++ b/openjpeg/openjpeg.json
@@ -1,0 +1,25 @@
+{
+  "name": "openjpeg",
+  "buildsystem": "cmake-ninja",
+  "builddir": true,
+  "config-opts": [
+    "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+    "-DBUILD_CODEC:BOOL=OFF",
+    "-DBUILD_DOC:BOOL=OFF",
+    "-DBUILD_STATIC_LIBS:BOOL=OFF",
+    "-DBUILD_TESTING:BOOL=OFF"
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
+      "sha256": "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9"
+    }
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/openjpeg-*",
+    "/lib/pkgconfig",
+    "/share"
+  ]
+}


### PR DESCRIPTION
A few apps on Flathub use it, in slightly different ways:

*   older versions
    *   com.github.junrrein.PDFSlicer uses 2.3.0
    *   fr.natron.Natron uses 2.3.0
    *   io.github.markummitchell.Engauge_Digitizer uses 2.3.0
    *   net.scribus.Scribus uses 2.3.0
    *   org.cvfosammmm.Setzer uses 2.3.0
    *   org.gnome.OCRFeeder uses 2.3.0
    *   org.videolan.VLC uses 2.3.0
*   uses cmake instead of cmake-ninja
    *   com.github.unrud.djpdf
*   builds unnecessary parts
    *   com.github.babluboy.bookworm builds the executabls, docs, tests and static libs
    *   com.github.junrrein.PDFSlicer builds the docs, tests and static libs
    *   fr.natron.Natron builds the executabls, docs, tests and static libs
    *   io.github.markummitchell.Engauge_Digitizer builds the executabls, docs, tests and static libs
    *   net.scribus.Scribus builds the docs, tests and static libs
    *   org.claws_mail.Claws-Mail builds the executabls, docs, tests and static libs
    *   org.cvfosammmm.Setzer builds the executabls, docs, tests and static libs
    *   org.gnome.OCRFeeder builds the executabls, docs, tests and static libs
    *   org.kde.okular builds the executabls, docs, tests and static libs
    *   org.videolan.VLC builds the executabls, docs, tests and static libs
*   could `cleanup` more
    *   com.github.babluboy.bookworm
    *   com.github.junrrein.PDFSlicer
    *   com.github.unrud.djpdf
    *   fr.natron.Natron
    *   net.scribus.Scribus
    *   org.claws_mail.Claws-Mail
    *   org.cvfosammmm.Setzer
    *   org.gnome.OCRFeeder
    *   org.kde.okular
    *   org.texstudio.TeXstudio
    *   org.videolan.VLC

Having this in shared-modules will improve things: fixed bugs and security issues for those apps updating to [the latest release](https://github.com/uclouvain/openjpeg/blob/v2.3.1/CHANGELOG.md), slightly faster builds and smaller results (by using cmake-ninja, building less and cleaning up more), etc…

If this is merged I'm going to send merge requests to all the apps using it to move them to the shared-modules version.