### PR TITLE
libappindicator: add dbus-glib dependency

### DIFF
--- a/libappindicator/libappindicator.json.in
+++ b/libappindicator/libappindicator.json.in
@@ -41,6 +41,7 @@
   ],
   "modules": [
     "../intltool/intltool-0.51.json",
+    "../dbus-glib/dbus-glib-0.110.json",
     {
       "name": "libdbusmenu",
       "build-options": {


### PR DESCRIPTION
otherwise it fails to build