### PR TITLE
Update libsecret to 0.20.1

### DIFF
--- a/libsecret/libsecret.json
+++ b/libsecret/libsecret.json
@@ -16,8 +16,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://ftp.gnome.org/pub/GNOME/sources/libsecret/0.20/libsecret-0.20.0.tar.xz",
-      "sha256": "f1187370b453106af878e30c284a121ba0c513da8bb4170b329d66e250bdae43"
+      "url": "https://ftp.gnome.org/pub/GNOME/sources/libsecret/0.20/libsecret-0.20.1.tar.xz",
+      "sha256": "57f73e94ec6263a17a077fb809cf8cf424637a897a7f15b4eec42ce4aef52447"
     }
   ]
 }


### PR DESCRIPTION
Successfully tested building flathub/ch.protonmail.protonmail-bridge.