### PR TITLE
Set up code owners for some modules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Fallback on Flathub admins for unowned shared modules
+*                  @flathub/reviewers
+
+/dbus-glib/        @TingPing
+/gtk2/             @TingPing
+/gudev/            @Erick555
+/intltool/         @TingPing
+/libappindicator/  @TingPing
+/libsecret/        @Lctrs
+/openjpeg/         @bochecha


### PR DESCRIPTION
As shared-modules grows and gets more security sensitive modules we
should have maintainers for each module so there is somebody taking
responsibility for what is here rather than it becoming a dumping
ground.

While we don't have yet owners for each module, some people already came
forward to commit to maintain some of them.

This change adds those people as owners of those modules, to begin
making some progress on #85.

---

I thought about making all unowned modules owned by the Flathub team, but not being a member of the Flathub organization I apparently can't see how the teams are called. :man_shrugging: 