### PR TITLE
misc: auto bump apps using shared-modules

### DIFF
--- a/.github/workflows/auto-mr.yml
+++ b/.github/workflows/auto-mr.yml
@@ -1,0 +1,14 @@
+name: auto PR
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: flathub/actions/shared-modules-auto-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.FLATHUBBOT_TOKEN }}


### PR DESCRIPTION
This adds a Github action to automatically bump all the apps using shared-modules when this repository gets updated. It doesn't check if the used modules by the app were updated or not yet, but that shouldn't be an issue for a first run I guess.

Shouldn't be merged until we add a secret token for flathubbot 

Depends on https://github.com/flathub/actions/pull/7
Fixes #92