### PR TITLE
glu: provide a build for 9.0.1

### DIFF
--- a/glu/glu-9.0.1.json
+++ b/glu/glu-9.0.1.json
@@ -1,0 +1,12 @@
+{
+  "name": "glu",
+  "config-opts": ["--disable-static"],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://mesa.freedesktop.org/archive/glu/glu-9.0.1.tar.xz",
+      "sha256": "fb5a4c2dd6ba6d1c21ab7c05129b0769544e1d68e1e3b0ffecb18e73c93055bc"
+    }
+  ],
+  "cleanup": [ "/include", "/lib/*.a", "/lib/*.la", "/lib/pkgconfig" ]
+}


### PR DESCRIPTION
Fixes a build issue with freedesktop 19.08 among possibly other things.