### PR TITLE
libappindicator: Apply another crash fix patch

### DIFF
--- a/libappindicator/libappindicator-fix-crash-iterating-icon-themes.patch
+++ b/libappindicator/libappindicator-fix-crash-iterating-icon-themes.patch
@@ -1,0 +1,13 @@
+diff --git a/libappindicator-12.10.0/src/app-indicator.c b/libappindicator-12.10.0/src/app-indicator.c
+index 2e98b48..715182d 100644
+--- a/libappindicator-12.10.0/src/app-indicator.c
++++ b/libappindicator-12.10.0/src/app-indicator.c
+@@ -1606,7 +1606,7 @@ status_icon_changes (AppIndicator * self, gpointer data)
+ 		gint n_elements, i;
+ 		gboolean found=FALSE;
+ 		gtk_icon_theme_get_search_path(icon_theme, &path, &n_elements);
+-		for (i=0; i< n_elements || path[i] == NULL; i++) {
++		for (i=0; i< n_elements; i++) {
+ 			if(g_strcmp0(path[i], self->priv->icon_theme_path) == 0) {
+ 				found=TRUE;
+ 				break;

--- a/libappindicator/libappindicator-gtk2-12.10.json
+++ b/libappindicator/libappindicator-gtk2-12.10.json
@@ -38,6 +38,10 @@
       "path": "libappindicator-fix-crash-from-incorrect-signal-emission.patch"
     },
     {
+      "type": "patch",
+      "path": "libappindicator-fix-crash-iterating-icon-themes.patch"
+    },
+    {
       "type": "script",
       "commands": ["autoreconf -sfi"],
       "dest-filename": "autogen.sh"

--- a/libappindicator/libappindicator-gtk3-12.10.json
+++ b/libappindicator/libappindicator-gtk3-12.10.json
@@ -38,6 +38,10 @@
       "path": "libappindicator-fix-crash-from-incorrect-signal-emission.patch"
     },
     {
+      "type": "patch",
+      "path": "libappindicator-fix-crash-iterating-icon-themes.patch"
+    },
+    {
       "type": "script",
       "commands": ["autoreconf -sfi"],
       "dest-filename": "autogen.sh"

--- a/libappindicator/libappindicator-gtk3-introspection-12.10.json
+++ b/libappindicator/libappindicator-gtk3-introspection-12.10.json
@@ -38,6 +38,10 @@
       "path": "libappindicator-fix-crash-from-incorrect-signal-emission.patch"
     },
     {
+      "type": "patch",
+      "path": "libappindicator-fix-crash-iterating-icon-themes.patch"
+    },
+    {
       "type": "script",
       "commands": ["autoreconf -sfi"],
       "dest-filename": "autogen.sh"

--- a/libappindicator/libappindicator.json.in
+++ b/libappindicator/libappindicator.json.in
@@ -38,6 +38,10 @@
       "path": "libappindicator-fix-crash-from-incorrect-signal-emission.patch"
     },
     {
+      "type": "patch",
+      "path": "libappindicator-fix-crash-iterating-icon-themes.patch"
+    },
+    {
       "type": "script",
       "commands": ["autoreconf -sfi"],
       "dest-filename": "autogen.sh"


### PR DESCRIPTION
From discussion in https://github.com/flathub/com.discordapp.Discord/issues/30

Based on 71810457bfa88d914e7570df04d86220fbafe3ed but should apply cleanly