### PR TITLE
libappindicator: Correct path in patch

### DIFF
--- a/libappindicator/libappindicator-fix-crash-iterating-icon-themes.patch
+++ b/libappindicator/libappindicator-fix-crash-iterating-icon-themes.patch
@@ -1,7 +1,5 @@
-diff --git a/libappindicator-12.10.0/src/app-indicator.c b/libappindicator-12.10.0/src/app-indicator.c
-index 2e98b48..715182d 100644
---- a/libappindicator-12.10.0/src/app-indicator.c
-+++ b/libappindicator-12.10.0/src/app-indicator.c
+--- libappindicator-12.10.0/src/app-indicator.c
++++ libappindicator-12.10.0/src/app-indicator.c
 @@ -1606,7 +1606,7 @@ status_icon_changes (AppIndicator * self, gpointer data)
  		gint n_elements, i;
  		gboolean found=FALSE;


### PR DESCRIPTION
Fix for the improper #96 .

Currently running locally built Discord on a locally built Electron2.BaseApp with this patch applied. Havn't had a crash yet.