### PR TITLE
gtk2: unhardcode libdir from ibus sub-module

### DIFF
--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -94,7 +94,7 @@
       ],
       "post-install": [
         "gtk-query-immodules-2.0 > immodules.cache",
-        "install immodules.cache -t $(pkg-config --variable=libdir gtk+-2.0)/gtk-2.0/$(pkg-config --variable=gtk_binary_version gtk+-2.0)/"
+        "install immodules.cache -t $(pkg-config --variable=libdir gtk+-2.0)/gtk-2.0/2.10.0/"
       ],
       "sources": [
         {

--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -68,7 +68,6 @@
     },
     {
       "name": "ibus-gtk2",
-      "no-make-install": true,
       "config-opts": [
         "--disable-xim",
         "--disable-dconf",
@@ -90,8 +89,8 @@
         "--disable-introspection",
         "--disable-python2"
       ],
-      "build-commands": [
-        "make -C client/gtk2 install"
+      "make-install-args": [
+        "-C", "client/gtk2"
       ],
       "post-install": [
         "gtk-query-immodules-2.0 > immodules.cache",

--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -90,12 +90,12 @@
         "--disable-introspection",
         "--disable-python2"
       ],
-      "ensure-writable": [
-        "/lib/gtk-2.0/2.10.0/immodules.cache"
+      "build-commands": [
+        "make -C client/gtk2 install"
       ],
       "post-install": [
-        "install -m644 --target-directory=${FLATPAK_DEST}/lib/gtk-2.0/2.10.0/immodules client/gtk2/.libs/im-ibus.so",
-        "gtk-query-immodules-2.0 > ${FLATPAK_DEST}/lib/gtk-2.0/2.10.0/immodules.cache"
+        "gtk-query-immodules-2.0 > immodules.cache",
+        "install immodules.cache -t $(pkg-config --variable=libdir gtk+-2.0)/gtk-2.0/$(pkg-config --variable=gtk_binary_version gtk+-2.0)/"
       ],
       "sources": [
         {


### PR DESCRIPTION
Use original makefile to install client library, and use pkg-config to determine full path to `immodules.cache`.
This would help builds where libdir is not `/app/lib`, e.g. in multilib case (those commonly set libdir to `/app/lib32`).