### PR TITLE
Added Linux Audio section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,4 @@
 /libsecret/        @Lctrs
 /openjpeg/         @bochecha
 /python2.7/        @bilelmoussaoui
+/linux-audio/      @hfiguiere

--- a/linux-audio/dssi.json
+++ b/linux-audio/dssi.json
@@ -1,0 +1,21 @@
+{
+    "name": "dssi",
+    "rm-configure": true,
+    "config-opts": [
+        "--disable-static"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://download.sf.net/sourceforge/dssi/dssi-1.1.1.tar.gz",
+            "sha256": "f2c82b073a947c8255284249097667f9b14e660bf86186f3fcd3b3b3e087814e"
+        },
+        {
+            "type": "script",
+            "commands": [
+                "autoreconf -fiv"
+            ],
+            "dest-filename": "autogen.sh"
+        }
+    ]
+}

--- a/linux-audio/fftw3f.json
+++ b/linux-audio/fftw3f.json
@@ -1,0 +1,32 @@
+{
+    "name": "fftw3f",
+    "config-opts": [
+        "--enable-threads",
+        "--enable-shared",
+        "--disable-static",
+        "--enable-float"
+    ],
+    "build-options": {
+        "arch": {
+            "x86_64": {
+                "config-opts": [
+                    "--enable-sse2",
+                    "--enable-avx",
+                    "--enable-avx-128-fma"
+                ]
+            }
+        }
+    },
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://www.fftw.org/fftw-3.3.8.tar.gz",
+            "sha256": "6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303"
+        }
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/*.la"
+    ]
+}

--- a/linux-audio/fluidsynth2.json
+++ b/linux-audio/fluidsynth2.json
@@ -1,0 +1,14 @@
+{
+    "name": "fluidsynth",
+    "buildsystem": "cmake-ninja",
+    "config-opts": [
+        "-DLIB_SUFFIX="
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.1.2.tar.gz",
+            "sha256": "9206d83b8d2f7e1ec259ee01e943071de67e419aabe142b51312f8edb39c5503"
+        }
+    ]
+}

--- a/linux-audio/jack2.json
+++ b/linux-audio/jack2.json
@@ -1,0 +1,16 @@
+{
+    "name": "jack2",
+    "buildsystem": "simple",
+    "build-commands": [
+        "./waf configure --prefix=/app --htmldir=/app/share/doc/jack/ --classic",
+        "./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "./waf install"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz",
+            "sha256": "a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c"
+        }
+    ]
+}

--- a/linux-audio/ladspa.json
+++ b/linux-audio/ladspa.json
@@ -1,0 +1,17 @@
+{
+    "name": "ladspa",
+    "no-autogen": true,
+    "subdir": "src",
+    "make-install-args": [
+        "INSTALL_PLUGINS_DIR=/app/lib/ladspa",
+        "INSTALL_INCLUDE_DIR=/app/include",
+        "INSTALL_BINARY_DIR=/app/bin"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://www.ladspa.org/download/ladspa_sdk_1.15.tgz",
+            "sha256": "4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded"
+        }
+    ]
+}

--- a/linux-audio/lash.json
+++ b/linux-audio/lash.json
@@ -1,0 +1,41 @@
+{
+    "name": "lash",
+    "rm-configure": true,
+    "config-opts": [
+        "--disable-static",
+        "--disable-serv-inst",
+        "CFLAGS=-D_GNU_SOURCE"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.savannah.gnu.org/releases/lash/lash-0.5.4.tar.gz",
+            "sha256": "105a7da84415c4725c6bcad28e70f23aeb4534f94fc80ca262b6a2cef2226c16"
+        },
+        {
+            "type": "patch",
+            "strip-components": 0,
+            "path": "patches/lash-0.5.3-no-static-lib.patch"
+        },
+        {
+            "type": "patch",
+            "path": "patches/lash-gcc47.patch"
+        },
+        {
+            "type": "patch",
+            "path": "patches/lash-linking.patch"
+        },
+        {
+            "type": "patch",
+            "strip-components": 0,
+            "path": "patches/lash-configure.patch"
+        },
+        {
+            "type": "script",
+            "commands": [
+                "autoreconf -fiv"
+            ],
+            "dest-filename": "autogen.sh"
+        }
+    ]
+}

--- a/linux-audio/libinstpatch.json
+++ b/linux-audio/libinstpatch.json
@@ -1,0 +1,17 @@
+{
+    "name": "libinstpatch",
+    "buildsystem": "cmake-ninja",
+    "config-opts": [
+        "-DLIB_SUFFIX="
+    ],
+    "cleanup": [
+	"/share/doc"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/swami/libinstpatch/archive/v1.1.4.tar.gz",
+            "sha256": "e529b15055b7341ab7a75885338d0a9b84859e3f6ca3ed3c363e7f3521329c9c"
+        }
+    ]
+}

--- a/linux-audio/liblo.json
+++ b/linux-audio/liblo.json
@@ -1,0 +1,10 @@
+{
+    "name": "liblo",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://download.sf.net/sourceforge/liblo/liblo-0.31.tar.gz",
+            "sha256": "2b4f446e1220dcd624ecd8405248b08b7601e9a0d87a0b94730c2907dbccc750"
+        }
+    ]
+}

--- a/linux-audio/lrdf.json
+++ b/linux-audio/lrdf.json
@@ -1,0 +1,49 @@
+{
+    "name": "lrdf",
+    "rm-configure": true,
+    "modules": [
+        "ladspa.json",
+        {
+            "name": "libxml2",
+            "config-opts": [
+                "--without-python",
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/GNOME/libxml2/archive/v2.9.8.tar.gz",
+                    "sha256": "ff879b0d9142564bfe63df9753df936f05150afdd7bae07261f12d4dad33ba4a"
+                }
+            ]
+        },
+        {
+            "name": "raptor2",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://download.librdf.org/source/raptor2-2.0.15.tar.gz",
+                    "sha256": "ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed"
+                }
+            ]
+        }
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/swh/LRDF/tarball/0.5.0",
+            "dest-filename": "swh-LRDF-0.5.0-0-g7ebc032.tar.gz",
+            "sha256": "013002b91ef209827fe99552b8c7f0b569cddb3d6f1439bedbd8bafe1956a93c"
+        },
+        {
+            "type": "script",
+            "commands": [
+                "autoreconf -fiv"
+            ],
+            "dest-filename": "autogen.sh"
+        }
+    ]
+}

--- a/linux-audio/lv2.json
+++ b/linux-audio/lv2.json
@@ -1,0 +1,20 @@
+{
+    "name": "lv2",
+    "buildsystem": "simple",
+    "build-commands": [
+        "python3 ./waf configure --prefix=/app --lv2dir=/app/lib/lv2 --copy-headers",
+        "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
+        "python3 ./waf install"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://lv2plug.in/spec/lv2-1.16.0.tar.bz2",
+            "sha256": "dec3727d7bd34a413a344a820678848e7f657b5c6019a0571c61df76d7bdf1de"
+        }
+    ],
+    "post-install": [
+        "install -Dm644 -t /app/share/licenses/lv2 COPYING",
+        "ln -sf /app/lib/pkgconfig/lv2.pc /app/lib/pkgconfig/lv2core.pc"
+    ]
+}

--- a/linux-audio/patches/lash-0.5.3-no-static-lib.patch
+++ b/linux-audio/patches/lash-0.5.3-no-static-lib.patch
@@ -1,0 +1,10 @@
+--- lash-1.0.pc.in~	2007-10-07 06:33:27.000000000 -0700
++++ lash-1.0.pc.in	2007-10-07 06:35:00.000000000 -0700
+@@ -7,6 +7,5 @@
+ Description: Audio session management
+ Requires: @PC_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -llash
+-Libs.static: -lpthread -luuid
++Libs: -llash -lpthread -luuid
+ Cflags: -I${includedir}/lash-1.0

--- a/linux-audio/patches/lash-configure.patch
+++ b/linux-audio/patches/lash-configure.patch
@@ -1,0 +1,11 @@
+--- configure.ac	2007-11-14 16:58:51.000000000 -0500
++++ configure.ac.new	2019-01-24 13:48:46.284377086 -0500
+@@ -2,7 +2,7 @@
+ AC_CONFIG_SRCDIR([lash/types.h])
+ AC_CONFIG_HEADER([config.h])
+ AM_INIT_AUTOMAKE
+-AM_ACLOCAL_INCLUDE([m4])
++dnl AM_ACLOCAL_INCLUDE([m4])
+ 
+ ### Check for programs ###
+ AC_LANG([C])

--- a/linux-audio/patches/lash-gcc47.patch
+++ b/linux-audio/patches/lash-gcc47.patch
@@ -1,0 +1,11 @@
+diff -rupN lash-0.5.4.old/liblash/lash.c lash-0.5.4/liblash/lash.c
+--- lash-0.5.4.old/liblash/lash.c	2007-03-09 10:34:40.000000000 -0500
++++ lash-0.5.4/liblash/lash.c	2012-07-22 18:17:46.003963521 -0400
+@@ -22,6 +22,7 @@
+ #include <string.h>
+ #include <strings.h>
+ #include <pthread.h>
++#include <sys/resource.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <sys/socket.h>

--- a/linux-audio/patches/lash-linking.patch
+++ b/linux-audio/patches/lash-linking.patch
@@ -1,0 +1,90 @@
+diff -rupN lash-0.5.4.old/clients/control/Makefile.am lash-0.5.4/clients/control/Makefile.am
+--- lash-0.5.4.old/clients/control/Makefile.am	2007-01-13 13:20:03.000000000 -0500
++++ lash-0.5.4/clients/control/Makefile.am	2010-02-10 03:08:04.000000000 -0500
+@@ -18,6 +18,6 @@ lash_control_CFLAGS = $(LASH_CFLAGS)
+ 
+ lash_control_LDADD = \
+ 	$(top_builddir)/liblash/liblash.la \
+-	$(LASH_LIBS) @READLINE_LIBS@
++	$(LASH_LIBS) @READLINE_LIBS@ -luuid
+ 
+ endif
+diff -rupN lash-0.5.4.old/clients/control/Makefile.in lash-0.5.4/clients/control/Makefile.in
+--- lash-0.5.4.old/clients/control/Makefile.in	2007-11-14 17:00:09.000000000 -0500
++++ lash-0.5.4/clients/control/Makefile.in	2010-02-10 03:09:26.000000000 -0500
+@@ -236,7 +236,7 @@ AM_CPPFLAGS = -I$(top_srcdir)
+ @HAVE_READLINE_TRUE@lash_control_CFLAGS = $(LASH_CFLAGS)
+ @HAVE_READLINE_TRUE@lash_control_LDADD = \
+ @HAVE_READLINE_TRUE@	$(top_builddir)/liblash/liblash.la \
+-@HAVE_READLINE_TRUE@	$(LASH_LIBS) @READLINE_LIBS@
++@HAVE_READLINE_TRUE@	$(LASH_LIBS) @READLINE_LIBS@ -luuid
+ 
+ all: all-am
+ 
+diff -rupN lash-0.5.4.old/clients/panel/Makefile.am lash-0.5.4/clients/panel/Makefile.am
+--- lash-0.5.4.old/clients/panel/Makefile.am	2005-09-13 01:22:59.000000000 -0400
++++ lash-0.5.4/clients/panel/Makefile.am	2010-02-10 03:17:10.000000000 -0500
+@@ -13,7 +13,7 @@ lash_panel_CFLAGS = \
+ 
+ lash_panel_LDADD = \
+ 	$(top_builddir)/liblash/liblash.la \
+-	$(GTK2_LIBS)
++	$(GTK2_LIBS) -luuid
+ 
+ if HAVE_GTK2
+   bin_PROGRAMS = lash_panel
+diff -rupN lash-0.5.4.old/clients/panel/Makefile.in lash-0.5.4/clients/panel/Makefile.in
+--- lash-0.5.4.old/clients/panel/Makefile.in	2007-11-14 17:00:09.000000000 -0500
++++ lash-0.5.4/clients/panel/Makefile.in	2010-02-10 03:17:23.000000000 -0500
+@@ -230,7 +230,7 @@ lash_panel_CFLAGS = \
+ 
+ lash_panel_LDADD = \
+ 	$(top_builddir)/liblash/liblash.la \
+-	$(GTK2_LIBS)
++	$(GTK2_LIBS) -luuid
+ 
+ all: all-am
+ 
+diff -rupN lash-0.5.4.old/clients/synth/Makefile.am lash-0.5.4/clients/synth/Makefile.am
+--- lash-0.5.4.old/clients/synth/Makefile.am	2005-09-13 01:22:59.000000000 -0400
++++ lash-0.5.4/clients/synth/Makefile.am	2010-02-10 03:22:39.000000000 -0500
+@@ -20,4 +20,4 @@ lash_synth_LDADD = \
+ 	$(JACK_LIBS) \
+ 	$(ALSA_LIBS) \
+ 	$(GTK2_LIBS) \
+-	-lpthread
++	-lpthread -lm
+diff -rupN lash-0.5.4.old/clients/synth/Makefile.in lash-0.5.4/clients/synth/Makefile.in
+--- lash-0.5.4.old/clients/synth/Makefile.in	2007-11-14 17:00:10.000000000 -0500
++++ lash-0.5.4/clients/synth/Makefile.in	2010-02-10 03:22:51.000000000 -0500
+@@ -238,7 +238,7 @@ lash_synth_LDADD = \
+ 	$(JACK_LIBS) \
+ 	$(ALSA_LIBS) \
+ 	$(GTK2_LIBS) \
+-	-lpthread
++	-lpthread -lm
+ 
+ all: all-am
+ 
+diff -rupN lash-0.5.4.old/lashd/Makefile.am lash-0.5.4/lashd/Makefile.am
+--- lash-0.5.4.old/lashd/Makefile.am	2006-09-16 16:27:46.000000000 -0400
++++ lash-0.5.4/lashd/Makefile.am	2010-07-23 15:13:59.000000000 -0400
+@@ -32,6 +32,7 @@ lashd_LDADD = \
+ 	$(ALSA_LIBS) \
+ 	$(XML2_LIBS) \
+ 	$(UUID_LIBS) \
++	-lpthread \
+ 	$(top_builddir)/liblash/liblash.la
+ 
+ lashd_CFLAGS = \
+diff -rupN lash-0.5.4.old/lashd/Makefile.in lash-0.5.4/lashd/Makefile.in
+--- lash-0.5.4.old/lashd/Makefile.in	2007-11-14 17:00:10.000000000 -0500
++++ lash-0.5.4/lashd/Makefile.in	2010-07-23 15:14:29.000000000 -0400
+@@ -262,6 +262,7 @@ lashd_LDADD = \
+ 	$(ALSA_LIBS) \
+ 	$(XML2_LIBS) \
+ 	$(UUID_LIBS) \
++	-lpthread \
+ 	$(top_builddir)/liblash/liblash.la
+ 
+ lashd_CFLAGS = \


### PR DESCRIPTION
This adds to shared modules some modules comonly found for Linux Audio. See for the base work to provide plugin support: flathub/flathub#1460 (it will need an update to point to the right repository)

- `fftw3f.json` : this is fftw3 with float (it's a separate build with a different configure option) and is found in a lot of flathub packages. I'm willing to progressively submit PR for these packages. This is not audio specific though, so I'm willing to move it in a different directory if you prefer.

- `ladspa.json`, `lrdf.json` : LADSPA plugin support. `lrdf` depends on `ladspa`, but `ladspa` is standalone otherwise.

- `lv2.json` : LV2 plugin support

- `dssi.json` , `liblo.json`: liblo provide OSC support and dssi provide DSSI support. Sometime DSSI plugin want OSC as well.  

