### PR TITLE
A bunch of fixes to the linux-audio shared-modules including lv2 build

### DIFF
--- a/linux-audio/dssi.json
+++ b/linux-audio/dssi.json
@@ -4,6 +4,13 @@
     "config-opts": [
         "--disable-static"
     ],
+    "cleanup": [
+      "/bin",
+      "/lib/dssi",
+      "/lib/pkgconfig",
+      "/share/man",
+      "*.la"
+    ],
     "sources": [
         {
             "type": "archive",

--- a/linux-audio/fftw3f.json
+++ b/linux-audio/fftw3f.json
@@ -27,6 +27,10 @@
     "cleanup": [
         "/bin",
         "/include",
-        "/lib/*.la"
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/man",
+        "*.la",
+        "*.so"
     ]
 }

--- a/linux-audio/fluidsynth2.json
+++ b/linux-audio/fluidsynth2.json
@@ -4,6 +4,13 @@
     "config-opts": [
         "-DLIB_SUFFIX="
     ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man",
+        "*.so"
+    ],
     "sources": [
         {
             "type": "archive",

--- a/linux-audio/liblo.json
+++ b/linux-audio/liblo.json
@@ -1,10 +1,17 @@
 {
-    "name": "liblo",
-    "sources": [
-        {
-            "type": "archive",
-            "url": "http://download.sf.net/sourceforge/liblo/liblo-0.31.tar.gz",
-            "sha256": "2b4f446e1220dcd624ecd8405248b08b7601e9a0d87a0b94730c2907dbccc750"
-        }
-    ]
+  "name": "liblo",
+  "cleanup": [
+    "/bin",
+    "/include",
+    "/lib/pkgconfig",
+    "*.la",
+    "*.so"
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "http://download.sf.net/sourceforge/liblo/liblo-0.31.tar.gz",
+      "sha256": "2b4f446e1220dcd624ecd8405248b08b7601e9a0d87a0b94730c2907dbccc750"
+    }
+  ]
 }

--- a/linux-audio/lrdf.json
+++ b/linux-audio/lrdf.json
@@ -4,20 +4,6 @@
     "modules": [
         "ladspa.json",
         {
-            "name": "libxml2",
-            "config-opts": [
-                "--without-python",
-                "--disable-static"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/GNOME/libxml2/archive/v2.9.8.tar.gz",
-                    "sha256": "ff879b0d9142564bfe63df9753df936f05150afdd7bae07261f12d4dad33ba4a"
-                }
-            ]
-        },
-        {
             "name": "raptor2",
             "config-opts": [
                 "--disable-static"

--- a/linux-audio/lv2.json
+++ b/linux-audio/lv2.json
@@ -2,9 +2,15 @@
     "name": "lv2",
     "buildsystem": "simple",
     "build-commands": [
-        "python3 ./waf configure --prefix=/app --lv2dir=/app/lib/lv2 --copy-headers",
+        "python3 ./waf configure --prefix=$FLATPAK_DEST --lv2dir=$FLATPAK_DEST/lib/lv2 --copy-headers",
         "python3 ./waf build -j $FLATPAK_BUILDER_N_JOBS",
         "python3 ./waf install"
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share"
     ],
     "sources": [
         {
@@ -14,7 +20,7 @@
         }
     ],
     "post-install": [
-        "install -Dm644 -t /app/share/licenses/lv2 COPYING",
-        "ln -sf /app/lib/pkgconfig/lv2.pc /app/lib/pkgconfig/lv2core.pc"
+        "install -Dm644 -t $FLATPAK_DEST/share/licenses/lv2 COPYING",
+        "ln -sf lv2.pc $FLATPAK_DEST/lib/pkgconfig/lv2core.pc"
     ]
 }


### PR DESCRIPTION
* lrdf to build libxml2 for no reason
* lv2 can now build in any prefix
* the rest is just cleanups.