### PR TITLE
glew: Update to version 2.2.0

### DIFF
--- a/glew/glew.json
+++ b/glew/glew.json
@@ -14,8 +14,8 @@
         "sources": [
                 {
                         "type": "archive",
-                        "url": "https://downloads.sourceforge.net/project/glew/glew/2.1.0/glew-2.1.0.tgz",
-                        "sha256": "04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95"
+                        "url": "https://downloads.sourceforge.net/project/glew/glew/2.2.0/glew-2.2.0.tgz",
+                        "sha256": "d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1"
                 }
         ],
         "cleanup": [


### PR DESCRIPTION
Let's update glew to version 2.2.0.
Fixes #107 issue.