### PR TITLE
lua5.3: Compile with hardening flags

### DIFF
--- a/lua5.3/lua-5.3.5.json
+++ b/lua5.3/lua-5.3.5.json
@@ -3,7 +3,9 @@
     "buildsystem": "simple",
     "build-commands": [
         "make CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_DLOPEN\" linux",
-        "make TO_LIB='liblua.so liblua.so.5.3 liblua.so.5.3.5' INSTALL_TOP=${FLATPAK_DEST} install",
+        "make TO_LIB=liblua.so.5.3.5 INSTALL_TOP=$FLATPAK_DEST install",
+        "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so",
+        "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so.5.3",
         "make INSTALL_TOP=${FLATPAK_DEST} pc > lua.pc",
         "cat lua.pc.in >> lua.pc",
         "install -Dm644 lua.pc $FLATPAK_DEST/lib/pkgconfig/lua.pc",

--- a/lua5.3/lua-5.3.5.json
+++ b/lua5.3/lua-5.3.5.json
@@ -2,7 +2,7 @@
     "name": "lua-5.3",
     "buildsystem": "simple",
     "build-commands": [
-        "make CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_DLOPEN\" linux",
+        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_DLOPEN\" linux",
         "make TO_LIB=liblua.so.5.3.5 INSTALL_TOP=$FLATPAK_DEST install",
         "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so",
         "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so.5.3",

--- a/lua5.3/lua-5.3.5.json
+++ b/lua5.3/lua-5.3.5.json
@@ -1,15 +1,9 @@
 {
     "name": "lua-5.3",
-    "no-autogen": true,
-    "make-args": [
-        "CFLAGS=-O2 -g -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_DLOPEN",
-        "linux"
-    ],
-    "make-install-args": [
-        "INSTALL_TOP=${FLATPAK_DEST}",
-        "TO_LIB=liblua.so liblua.so.5.3 liblua.so.5.3.5"
-    ],
-    "post-install": [
+    "buildsystem": "simple",
+    "build-commands": [
+        "make CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_DLOPEN\" linux",
+        "make TO_LIB='liblua.so liblua.so.5.3 liblua.so.5.3.5' INSTALL_TOP=${FLATPAK_DEST} install",
         "make INSTALL_TOP=${FLATPAK_DEST} pc > lua.pc",
         "cat lua.pc.in >> lua.pc",
         "install -Dm644 lua.pc $FLATPAK_DEST/lib/pkgconfig/lua.pc",


### PR DESCRIPTION
Use `$CFLAGS` as defined by the SDK.
Also use symlinks for the libraries instead of copies because the loader might print a warning.