### PR TITLE
Patch libsecret to correctly initialize libgcrypt

### DIFF
--- a/libsecret/libsecret-init-gcrypt-for-file-collection.patch
+++ b/libsecret/libsecret-init-gcrypt-for-file-collection.patch
@@ -1,0 +1,21 @@
+diff --git a/libsecret/secret-file-collection.c b/libsecret/secret-file-collection.c
+index 2e90e3c..a27cf04 100644
+--- a/libsecret/secret-file-collection.c
++++ b/libsecret/secret-file-collection.c
+@@ -16,6 +16,7 @@
+ 
+ #include "secret-file-collection.h"
+ 
++#include "egg/egg-libgcrypt.h"
+ #include "egg/egg-secure-memory.h"
+ 
+ EGG_SECURE_DECLARE (secret_file_collection);
+@@ -271,6 +272,8 @@ secret_file_collection_class_init (SecretFileCollectionClass *klass)
+ 		   g_param_spec_boxed ("password", "password", "Password",
+ 				       SECRET_TYPE_VALUE,
+ 				       G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
++
++	egg_libgcrypt_initialize ();
+ }
+ 
+ static void

--- a/libsecret/libsecret.json
+++ b/libsecret/libsecret.json
@@ -18,6 +18,10 @@
       "type": "archive",
       "url": "https://ftp.gnome.org/pub/GNOME/sources/libsecret/0.20/libsecret-0.20.3.tar.xz",
       "sha256": "4fcb3c56f8ac4ab9c75b66901fb0104ec7f22aa9a012315a14c0d6dffa5290e4"
+    },
+    {
+      "type": "patch",
+      "path": "libsecret-init-gcrypt-for-file-collection.patch"
     }
   ]
 }


### PR DESCRIPTION
Apply https://gitlab.gnome.org/GNOME/libsecret/-/merge_requests/56

The global thread unsafety still remains, but at least it won't be triggered between threads using libsecret any more.

Fixes https://github.com/flathub/com.visualstudio.code/issues/159