### PR TITLE
Improve lua5.1 and lua5.3 build scripts

### DIFF
--- a/lua5.1/lua-5.1.5.json
+++ b/lua5.1/lua-5.1.5.json
@@ -2,7 +2,7 @@
     "name": "lua-5.1",
     "buildsystem": "simple",
     "build-commands": [
-        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC\" linux",
+        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC -DLUA_USE_LINUX\" linux",
         "make INSTALL_TOP=$FLATPAK_DEST TO_LIB='liblua.a liblua.so.5.1.5' install",
         "ln -sf liblua.so.5.1.5 $FLATPAK_DEST/lib/liblua.so",
         "ln -sf liblua.so.5.1.5 $FLATPAK_DEST/lib/liblua.so.5.1",

--- a/lua5.3/lua-5.3.5.json
+++ b/lua5.3/lua-5.3.5.json
@@ -2,7 +2,7 @@
     "name": "lua-5.3",
     "buildsystem": "simple",
     "build-commands": [
-        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_DLOPEN\" linux",
+        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_LINUX\" linux",
         "make TO_LIB=liblua.so.5.3.5 INSTALL_TOP=$FLATPAK_DEST install",
         "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so",
         "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so.5.3",

--- a/lua5.3/lua-5.3.5.json
+++ b/lua5.3/lua-5.3.5.json
@@ -2,7 +2,7 @@
     "name": "lua-5.3",
     "buildsystem": "simple",
     "build-commands": [
-        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC -DLUA_COMPAT_5_2 -DLUA_COMPAT_5_1 -DLUA_USE_LINUX\" linux",
+        "make -j $FLATPAK_BUILDER_N_JOBS CFLAGS=\"$CFLAGS -fPIC -DLUA_USE_LINUX\" linux",
         "make TO_LIB=liblua.so.5.3.5 INSTALL_TOP=$FLATPAK_DEST install",
         "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so",
         "ln -sf liblua.so.5.3.5 $FLATPAK_DEST/lib/liblua.so.5.3",
@@ -32,7 +32,8 @@
             "commands": [
                 "sed -i \"s|/usr/local/|$FLATPAK_DEST/|;s|LUA_IDSIZE	60|LUA_IDSIZE	512|\" src/luaconf.h",
                 "# Lua 5.3.5 has wrong release version in its Makefile. Fix it.",
-                "sed 's/^R= \$V.4/R= \$V.5/' -i Makefile"
+                "sed 's/^R= \$V.4/R= \$V.5/' -i Makefile",
+                "sed -i '12 a\\\\n#define LUA_COMPAT_5_1\\n#define LUA_COMPAT_5_2' src/luaconf.h"
             ]
         }
     ],


### PR DESCRIPTION
* lua5.{1,3}: Use **LUA_USE_LINUX**
  This should be set by `make ... linux` but we overwrite `CFLAGS`.
  **LUA_USE_LINUX** sets **LUA_USE_DLOPEN** and **LUA_USE_READLINE**.
* lua5.3: Set **LUA_COMPAT_5_{1,2}** in header file
  Fixes #116
  The problem was introduced in https://github.com/flathub/shared-modules/commit/24ae80a6fcb034f155402a7006408e224ac86470. The macros need to be set in the include header files not only at compile time.