### PR TITLE
Add libhandy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 /gudev/            @Erick555
 /intltool/         @TingPing
 /libappindicator/  @TingPing
+/libhandy/         @A6GibKm
 /libsecret/        @Lctrs
 /libusb/           @A6GibKm
 /openjpeg/         @bochecha

--- a/libhandy/libhandy-0.json
+++ b/libhandy/libhandy-0.json
@@ -1,0 +1,18 @@
+{
+    "name" : "libhandy-0",
+    "buildsystem" : "meson",
+    "config-opts" : [
+        "-Dexamples=false",
+        "-Dglade_catalog=disabled",
+        "-Dintrospection=disabled",
+        "-Dtests=false",
+        "-Dvapi=false"
+    ],
+    "sources" : [
+        {
+            "type": "archive",
+            "url": "https://gitlab.gnome.org/GNOME/libhandy/-/archive/v0.0.13/libhandy-v0.0.13.tar.gz",
+            "sha256": "645355a009f23f254eaec7752b9489c3c2f5832397fcec75433a7e00efbfe52f"
+        }
+    ]
+}

--- a/libhandy/libhandy-1.json
+++ b/libhandy/libhandy-1.json
@@ -1,0 +1,18 @@
+{
+    "name" : "libhandy-1",
+    "buildsystem" : "meson",
+    "config-opts" : [
+        "-Dexamples=false",
+        "-Dglade_catalog=disabled",
+        "-Dintrospection=disabled",
+        "-Dtests=false",
+        "-Dvapi=false"
+    ],
+    "sources" : [
+        {
+            "type": "archive",
+            "url": "https://download.gnome.org/sources/libhandy/1.0/libhandy-1.0.0.tar.xz",
+            "sha256": "a9398582f47b7d729205d6eac0c068fef35aaf249fdd57eea3724f8518d26699"
+        }
+    ]
+}


### PR DESCRIPTION
Also added older libhandy v0.13.0 since many packages depend on it and it should
require zero maintenance.

- Note that this probably won't work for Glade since it sets `glade_catalog=false`, I don't know if there is a real reason to remove the catalog for `libhandy-1` in any case.

- I am debating if 0.13.0 should use the old Purism source or the newer gitlab.gnome.org source. @bilelmoussaoui Do you think GNOME could add a source for libhandy-0 under [https://download.gnome.org/sources/libhandy/](download.gnome.org/sources/libhandy)?

While I can maintain this, I don't have the time right now to send PRs to the 51+ repos who use some version of libhandy acording to [this search](https://github.com/search?q=org%3Aflathub+libhandy&type=code). I guess it only makes sense to push to repos using versions V satisfying 0.13.0 < V =< 1.0.0, which should not be that many. When I have the time I will remove the draft status. 
