### PR TITLE
linux-audio: build fftw3f with neon on aarch64

### DIFF
--- a/linux-audio/fftw3f-static.json
+++ b/linux-audio/fftw3f-static.json
@@ -17,6 +17,11 @@
           "--enable-avx",
           "--enable-avx-128-fma"
         ]
+      },
+      "aarch64": {
+          "config-opts": [
+              "--enable-neon"
+          ]
       }
     }
   },

--- a/linux-audio/fftw3f.json
+++ b/linux-audio/fftw3f.json
@@ -14,6 +14,11 @@
                     "--enable-avx",
                     "--enable-avx-128-fma"
                 ]
+            },
+            "aarch64": {
+                "config-opts": [
+                    "--enable-neon"
+                ]
             }
         }
     },


### PR DESCRIPTION
I need to test this more, but fftw3 want `--enable-neon` to build NEON support on aarch64.