### PR TITLE
intltool: patch regex errors in intltool-update

### DIFF
--- a/intltool/intltool-0.51.json
+++ b/intltool/intltool-0.51.json
@@ -6,6 +6,10 @@
       "type": "archive",
       "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
       "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+    },
+    {
+      "type": "patch",
+      "path": "intltool-perl5.26-regex-fixes.patch"
     }
   ]
 }

--- a/intltool/intltool-perl5.26-regex-fixes.patch
+++ b/intltool/intltool-perl5.26-regex-fixes.patch
@@ -1,0 +1,59 @@
+Description: Escape "{", to prevent complaints from perl 5.22 and 5.26
+Author: Roderich Schupp <roderich.schupp@gmail.com>
+Author: gregor herrmann <gregoa@debian.org>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=788705
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826471
+Bug-Upstream: https://bugs.launchpad.net/intltool/+bug/1490906
+
+Index: intltool-0.51.0/intltool-update.in
+===================================================================
+--- intltool-0.51.0.orig/intltool-update.in	2017-07-23 17:24:35.113169465 +0200
++++ intltool-0.51.0/intltool-update.in	2017-07-23 17:24:35.109169052 +0200
+@@ -1062,13 +1062,13 @@
+ 	}
+     }
+ 
+-    if ($str =~ /^(.*)\${?([A-Z_]+)}?(.*)$/)
++    if ($str =~ /^(.*)\$\{?([A-Z_]+)}?(.*)$/)
+     {
+ 	my $rest = $3;
+ 	my $untouched = $1;
+ 	my $sub = "";
+         # Ignore recursive definitions of variables
+-        $sub = $varhash{$2} if defined $varhash{$2} and $varhash{$2} !~ /\${?$2}?/;
++        $sub = $varhash{$2} if defined $varhash{$2} and $varhash{$2} !~ /\$\{?$2}?/;
+ 
+ 	return SubstituteVariable ("$untouched$sub$rest");
+     }
+@@ -1190,10 +1190,10 @@
+ 	$name    =~ s/\(+$//g;
+ 	$version =~ s/\(+$//g;
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
+     }
+ 
+     if ($conf_source =~ /^AC_INIT\(([^,\)]+),([^,\)]+)[,]?([^,\)]+)?/m)
+@@ -1219,11 +1219,11 @@
+ 	$version =~ s/\(+$//g;
+         $bugurl  =~ s/\(+$//g if (defined $bugurl);
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
+-        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\${?\w+}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
++        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\$\{?\w+}?/);
+     }
+ 
+     # \s makes this not work, why?


### PR DESCRIPTION
While debugging an i18n/l10n issue with org.soundconverter.SoundConverter (https://github.com/flathub/flathub/pull/1946), I found these messages in the log of `flatpak-builder`:

```
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/^(.*)\${ <-- HERE ?([A-Z_]+)}?(.*)$/ at /app/bin/intltool-update line 1065.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?AC_PACKAGE_NAME}?/ at /app/bin/intltool-update line 1193.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?PACKAGE}?/ at /app/bin/intltool-update line 1194.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?AC_PACKAGE_VERSION}?/ at /app/bin/intltool-update line 1195.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?VERSION}?/ at /app/bin/intltool-update line 1196.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?AC_PACKAGE_NAME}?/ at /app/bin/intltool-update line 1222.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?PACKAGE}?/ at /app/bin/intltool-update line 1223.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?AC_PACKAGE_VERSION}?/ at /app/bin/intltool-update line 1224.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?VERSION}?/ at /app/bin/intltool-update line 1225.
Unescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\${ <-- HERE ?\w+}?/ at /app/bin/intltool-update line 1226.
```

A little research brought up that this is an old issue with upstream intltool, but has been patched basically everywhere else, so I copied the patch to be added here as well.

Patch taken from:
https://src.fedoraproject.org/rpms/intltool/raw/master/f/intltool-perl5.26-regex-fixes.patch

Upstream bug report: https://bugs.launchpad.net/intltool/+bug/1490906