### PR TITLE
gtk2: Update gtk to 15.23 (final release)

### DIFF
--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -57,8 +57,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.32.tar.xz",
-          "sha256": "b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e"
+          "url": "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.33.tar.xz",
+          "sha256": "ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da"
         },
         {
           "type": "patch",


### PR DESCRIPTION
Gtk2 is now End-of-life. We should keep it supported for backwards compatbility, but upstream projects should be encouraged to move on to Gtk 3 or Gtk 4