### PR TITLE
Add libcanberra

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,6 +6,7 @@
 /gudev/            @Erick555
 /intltool/         @TingPing
 /libappindicator/  @TingPing
+/libcanberra/      @hadess
 /libsecret/        @Lctrs
 /libusb/           @A6GibKm
 /openjpeg/         @bochecha

--- a/libcanberra/0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
+++ b/libcanberra/0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
@@ -1,0 +1,70 @@
+From c0620e432650e81062c1967cc669829dbd29b310 Mon Sep 17 00:00:00 2001
+From: Michael Meeks <michael.meeks@suse.com>
+Date: Fri, 9 Nov 2012 16:16:40 +0000
+Subject: [PATCH] gtk: Don't assume all GdkDisplays are GdkX11Displays:
+ broadway/wayland
+
+---
+ src/canberra-gtk-module.c | 15 +++++++++++++++
+ src/canberra-gtk.c        |  5 +++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/src/canberra-gtk-module.c b/src/canberra-gtk-module.c
+index 67791f0..c1532ab 100644
+--- a/src/canberra-gtk-module.c
++++ b/src/canberra-gtk-module.c
+@@ -307,6 +307,11 @@ static gint window_get_desktop(GdkDisplay *d, GdkWindow *w) {
+         guchar *data = NULL;
+         gint ret = -1;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return 0;
++#endif
++
+         if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), GDK_WINDOW_XID(w),
+                                gdk_x11_get_xatom_by_name_for_display(d, "_NET_WM_DESKTOP"),
+                                0, G_MAXLONG, False, XA_CARDINAL, &type_return,
+@@ -335,6 +340,11 @@ static gint display_get_desktop(GdkDisplay *d) {
+         guchar *data = NULL;
+         gint ret = -1;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return 0;
++#endif
++
+         if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), DefaultRootWindow(GDK_DISPLAY_XDISPLAY(d)),
+                                gdk_x11_get_xatom_by_name_for_display(d, "_NET_CURRENT_DESKTOP"),
+                                0, G_MAXLONG, False, XA_CARDINAL, &type_return,
+@@ -365,6 +375,11 @@ static gboolean window_is_xembed(GdkDisplay *d, GdkWindow *w) {
+         gboolean ret = FALSE;
+         Atom xembed;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return FALSE;
++#endif
++
+         /* Gnome Panel applets are XEMBED windows. We need to make sure we
+          * ignore them */
+ 
+diff --git a/src/canberra-gtk.c b/src/canberra-gtk.c
+index 34446f5..08cb668 100644
+--- a/src/canberra-gtk.c
++++ b/src/canberra-gtk.c
+@@ -185,6 +185,11 @@ static gint window_get_desktop(GdkDisplay *d, GdkWindow *w) {
+         guchar *data = NULL;
+         gint ret = -1;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return 0;
++#endif
++
+         if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), GDK_WINDOW_XID(w),
+                                gdk_x11_get_xatom_by_name_for_display(d, "_NET_WM_DESKTOP"),
+                                0, G_MAXLONG, False, XA_CARDINAL, &type_return,
+-- 
+2.29.2
+

--- a/libcanberra/libcanberra.json
+++ b/libcanberra/libcanberra.json
@@ -1,0 +1,35 @@
+{
+    "name": "libcanberra",
+    "cleanup": [
+        "*.la",
+        "/bin",
+        "/etc",
+        "/include",
+        "/libexec",
+        "/share/gtk-doc",
+        "/share/man"
+    ],
+    "config-opts": [
+        "--disable-static",
+        "--disable-gtk-doc",
+        "--disable-oss",
+        "--enable-pulse",
+        "--disable-udev",
+        "--disable-gtk",
+        "--enable-gtk3",
+        "--disable-lynx"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+            "sha256": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72",
+            "git-init" : true
+        },
+        {
+            "type": "patch",
+            "path": "0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch",
+            "use-git-am": true
+        }
+    ]
+}


### PR DESCRIPTION
It's used by about 20 different Flathub modules, and the last released
version doesn't include a particular bad bug fix which would cause
applications to assert() when used on Wayland, as they try to access
the X11 display.