### PR TITLE
Add GZDoom as a shared-module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,3 +15,4 @@
 /lua5.1/           @Unrud
 /mac/              @enzo1982 @Eonfge
 /pygtk/            @Eonfge
+/gzdoom/           @Eonfge

--- a/gzdoom/description.patch
+++ b/gzdoom/description.patch
@@ -1,0 +1,18 @@
+diff --git a/src/d_iwad.cpp b/src/d_iwad.cpp
+index b421b1b35..9f0b16948 100644
+--- a/src/d_iwad.cpp
++++ b/src/d_iwad.cpp
+@@ -683,9 +683,10 @@ int FIWadManager::IdentifyVersion (TArray<FString> &wadfiles, const char *iwad,
+ 					  "2. Edit your ~/Library/Preferences/" GAMENAMELOWERCASE ".ini and add the directories\n"
+ 					  "of your iwads to the list beneath [IWADSearch.Directories]");
+ #else
+-					  "1. Place one or more of these wads in ~/.config/" GAMENAMELOWERCASE "/.\n"
+-					  "2. Edit your ~/.config/" GAMENAMELOWERCASE "/" GAMENAMELOWERCASE ".ini and add the directories of your\n"
+-					  "iwads to the list beneath [IWADSearch.Directories]");
++					  "1. Place one or more of these wads in ~/.var/app/org.zdoom.GZDoom/.config/" GAMENAMELOWERCASE "/\n"
++					  "2. Edit your ~/.var/app/org.zdoom.GZDoom/.config/" GAMENAMELOWERCASE "/" GAMENAMELOWERCASE ".ini and\n"
++					  "     add the directories of your iwads to the list beneath [IWADSearch.Directories]\n"
++					  "3. Validate your Flatpak permissions, so that Flatpak has access to your directories with wads");
+ #endif
+ 	}
+ 	int pick = 0;

--- a/gzdoom/gzdoom.json
+++ b/gzdoom/gzdoom.json
@@ -1,0 +1,50 @@
+{
+    "name": "gzdoom",
+    "buildsystem": "cmake-ninja",
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    ],
+    "cleanup": [
+        "/lib/*.a",
+        "/lib/*.la",
+        "/lib/pkgconfig",
+        "/include"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/coelckers/gzdoom.git",
+            "tag": "g4.6.0",
+            "commit": "c320db66f4b31256d5ad400610a2e1fab028dfe7"
+        },
+        {
+            "type": "file",
+            "url": "https://github.com/coelckers/gzdoom/raw/g4.6.0/soundfont/gzdoom.sf2",
+            "sha256": "fca3e514b635a21789d4224e84865d2954a2a914d46b64aa8219ddb565c44869"
+        },
+        /* I've discussed these patches upstream and a special -DFLATPAK_BUNDLE has been approved */
+        {
+            "type": "patch",
+            "path": "description.patch"
+        }
+    ],
+    "post-install": [
+        "install -Dm 644 gzdoom.sf2 /app/share/sounds/sf2/gzdoom.sf2"
+    ],
+    "modules": [
+        {
+            "name": "zmusic",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/coelckers/ZMusic/archive/1.1.8.tar.gz",
+                    "sha256": "73082f661b7b0bb33348d1d186c132deec9132a1613480348a00172b49c9fd68"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I've rolled into maintaining both GZDoom and the FreeDoom packages, but this is mostly just copy-pasting the same basic configuration. As such, I wish to propose a special shared module that can be used by other projects, like Blade of Agony, to share dependencies.

@Alexander-Wilms I hope you find this an interesting proposition. I've also made an upstream request to better support Flatpak in the future, although that should be of no issue in case of third-party IWADs