### PR TITLE
[WIP] Add PyQt and PyQtWebEngine

### DIFF
--- a/dbus-python/dbus-python.json
+++ b/dbus-python/dbus-python.json
@@ -1,0 +1,21 @@
+{
+    "name": "dbus-python",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-python\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/62/7e/d4fb56a1695fa65da0c8d3071855fa5408447b913c58c01933c2f81a269a/dbus-python-1.2.16.tar.gz",
+            "sha256": "11238f1d86c995d8aed2e22f04a1e3779f0d70e587caffeab4857f3c662ed5a4",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "dbus-python"
+            }
+        }
+    ],
+    "cleanup": [
+        "*.la"
+    ]
+}

--- a/freeglut/freeglut.json
+++ b/freeglut/freeglut.json
@@ -1,0 +1,31 @@
+{
+    "name": "freeglut",
+    "buildsystem": "cmake",
+    "build-options": {
+        "cflags": "-fcommon"
+    },
+    "config-opts": [
+        "-DFREEGLUT_BUILD_STATIC_LIBS=OFF",
+        "-DCMAKE_BUILD_TYPE=None"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz",
+            "sha256": "d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68",
+            "x-checker-data": {
+                "type": "anitya",
+                "project-id": "846",
+                "url-template": "https://downloads.sourceforge.net/freeglut/freeglut-$version.tar.gz"
+            }
+        }
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig"
+    ],
+    "modules": [
+        "../glu/glu-9.json"
+    ]
+}

--- a/pyqt/README.md
+++ b/pyqt/README.md
@@ -1,0 +1,53 @@
+# PyQt and PyQtWebEngine
+
+Version 5 of PyQt and PyQtWebEngine Python binding as Flatpak shared modules.
+
+## Details
+
+These modules require the KDE 5.15 runtime. The PyQtWebEngine module also depends on the [QtWebEngine base app](https://github.com/flathub/io.qt.qtwebengine.BaseApp/).
+
+Both already include the following modules that will be packaged with your app:
+
+* dbus-python
+* freeglut
+* python-opengl
+* python-packaging
+* python-pyparsing
+* python-toml
+
+## Usage examples
+
+### Example: PyQt5 app
+
+```
+  app-id: org.flathub.PyQtApp
+  runtime: org.kde.Platform
+  runtime-version: '5.15'
+  sdk: org.kde.Sdk
+  modules:
+    - name: app
+      modules:
+        - shared-modules/pyqt/pyqt5.json
+```
+
+### Example: PyQt5WebEngine app
+
+```
+  app-id: org.flathub.PyQtWebEngineApp
+  runtime: org.kde.Platform
+  runtime-version: '5.15'
+  sdk: org.kde.Sdk
+  base: io.qt.qtwebengine.BaseApp
+  base-version: '5.15'
+  finish-args:
+    - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
+  cleanup-commands:
+    - /app/cleanup-BaseApp.sh
+  modules:
+    - name: app
+      build-options:
+        env:
+          - QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
+      modules:
+        - shared-modules/pyqt/pyqt5-webengine.json
+```

--- a/pyqt/pyqt5-webengine.json
+++ b/pyqt/pyqt5-webengine.json
@@ -1,0 +1,43 @@
+{
+    "name": "pyqt5-webengine",
+    "build-options": {
+        "env": [
+            "QMAKEPATH=/app/lib"
+        ]
+    },
+    "config-opts": [
+        "--concatenate",
+        "--no-dist-info",
+        "--no-docstrings",
+        "--no-qsci-api",
+        "--no-sip-files",
+        "--verbose",
+        "QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "QMAKE_INCDIR+=/app/include/QtWebEngine",
+        "QMAKE_INCDIR+=/app/include/QtWebEngineCore",
+        "QMAKE_INCDIR+=/app/include/QtWebEngineWidgets"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://pypi.python.org/packages/source/P/PyQtWebEngine/PyQtWebEngine-5.15.4.tar.gz",
+            "sha256": "cedc28f54165f4b8067652145aec7f732a17eadf6736835852868cf76119cc19",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "PyQtWebEngine"
+            }
+        },
+        {
+            "type": "script",
+            "commands": [
+                "processed=`sed -e 's|prefix|sysroot|' <<< $@`",
+                "python3 configure.py $processed"
+            ],
+            "dest-filename": "configure"
+        }
+    ],
+    "modules": [
+        "pyqt5.json"
+    ]
+}

--- a/pyqt/pyqt5-webengine.json
+++ b/pyqt/pyqt5-webengine.json
@@ -6,22 +6,25 @@
         ]
     },
     "config-opts": [
-        "--concatenate",
-        "--no-dist-info",
+        "--concatenate=1",
         "--no-docstrings",
-        "--no-qsci-api",
-        "--no-sip-files",
         "--verbose",
-        "QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/'",
-        "QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'",
-        "QMAKE_INCDIR+=/app/include/QtWebEngine",
-        "QMAKE_INCDIR+=/app/include/QtWebEngineCore",
-        "QMAKE_INCDIR+=/app/include/QtWebEngineWidgets"
+        "--qmake-setting=QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "--qmake-setting=QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "--qmake-setting=QMAKE_INCDIR+=/app/include/QtWebEngine",
+        "--qmake-setting=QMAKE_INCDIR+=/app/include/QtWebEngineCore",
+        "--qmake-setting=QMAKE_INCDIR+=/app/include/QtWebEngineWidgets"
+    ],
+    "make-args": [
+        "--directory=build"
+    ],
+    "make-install-args": [
+        "--directory=build"
     ],
     "sources": [
         {
             "type": "archive",
-            "url": "https://pypi.python.org/packages/source/P/PyQtWebEngine/PyQtWebEngine-5.15.4.tar.gz",
+            "url": "https://files.pythonhosted.org/packages/fb/5d/4c5bb7adca4f2436545a391fe311dcb4ccc711f1ce2ab7adb87475ec566e/PyQtWebEngine-5.15.4.tar.gz",
             "sha256": "cedc28f54165f4b8067652145aec7f732a17eadf6736835852868cf76119cc19",
             "x-checker-data": {
                 "type": "pypi",
@@ -31,8 +34,9 @@
         {
             "type": "script",
             "commands": [
-                "processed=`sed -e 's|prefix|sysroot|' <<< $@`",
-                "python3 configure.py $processed"
+                "processed=`sed -e 's|prefix=/app|target-dir=/app/lib/python3.8/site-packages|' <<< $@`",
+                "sip-build $processed",
+                "echo 'trick flatpak-builder into running make' > Makefile"
             ],
             "dest-filename": "configure"
         }

--- a/pyqt/pyqt5.json
+++ b/pyqt/pyqt5.json
@@ -1,8 +1,7 @@
 {
     "name": "pyqt5",
     "config-opts": [
-        "--assume-shared",
-        "--concatenate",
+        "--concatenate=1",
         "--confirm-license",
         "--enable=QtCore",
         "--enable=QtDBus",
@@ -17,28 +16,25 @@
         "--enable=QtWebChannel",
         "--enable=QtWidgets",
         "--no-designer-plugin",
-        "--no-dist-info",
         "--no-docstrings",
+        "--no-make",
         "--no-qml-plugin",
-        "--no-qsci-api",
-        "--no-stubs",
         "--no-tools",
-        "QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/'",
-        "QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'"
+        "--api-dir=/app/share/qt/qsci/api/python",
+        "--qmake-setting=QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "--qmake-setting=QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "--qt-shared"
     ],
-    "build-options": {
-        "arch": {
-            "aarch64": {
-                "config-opts": [
-                    "--disable-feature=PyQt_Desktop_OpenGL"
-                ]
-            }
-        }
-    },
+    "make-args": [
+        "--directory=build"
+    ],
+    "make-install-args": [
+        "--directory=build"
+    ],
     "sources": [
         {
             "type": "archive",
-            "url": "https://pypi.python.org/packages/source/P/PyQt5/PyQt5-5.15.4.tar.gz",
+            "url": "https://files.pythonhosted.org/packages/8e/a4/d5e4bf99dd50134c88b95e926d7b81aad2473b47fde5e3e4eac2c69a8942/PyQt5-5.15.4.tar.gz",
             "sha256": "2a69597e0dd11caabe75fae133feca66387819fc9bc050f547e5551bce97e5be",
             "x-checker-data": {
                 "type": "pypi",
@@ -48,18 +44,72 @@
         {
             "type": "script",
             "commands": [
-                "processed=`sed -e 's|prefix|sysroot|' <<< $@`",
-                "python3 configure.py $processed"
+                "processed=`sed -e 's|prefix=/app|target-dir=/app/lib/python3.8/site-packages|' <<< $@`",
+                "sip-build $processed",
+                "echo 'trick flatpak-builder into running make' > Makefile"
             ],
             "dest-filename": "configure"
+        },
+        {
+            "type": "shell",
+            "commands": [
+                "echo '[tool.sip.bindings.QtGui]' >> pyproject.toml",
+                "echo 'disabled-features = [\"PyQt_Desktop_OpenGL\"]' >> pyproject.toml"
+            ],
+            "only-arches": [
+                "aarch64"
+            ]
         }
     ],
     "cleanup": [
-        "/share/sip"
+        "/share/sip",
+        /* removing qsci (qscintilla api)*/
+        "/share/qt"
     ],
     "modules": [
         "../dbus-python/dbus-python.json",
         "../python-opengl/python-opengl.json",
-        "sip.json"
+        "sip.json",
+        {
+            "name": "pyqt-builder",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python setup.py build",
+                "python setup.py install --skip-build --prefix=/app --root=/ --optimize=1"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://files.pythonhosted.org/packages/00/a4/67939cced6487b1856dfda5cafa4e7eb179df917f4964918a202c8ba46d3/PyQt-builder-1.10.1.tar.gz",
+                    "sha256": "967b0c7bac0331597e9f8c5b336660f173a9896830b721d6d025e14bde647e17",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "PyQt-builder"
+                    }
+                }
+            ],
+            "cleanup": [
+                "*"
+            ]
+        },
+        {
+            "name": "pyqt5-sip",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python setup.py build",
+                "python setup.py install --skip-build --prefix=/app --root=/ --optimize=1"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://files.pythonhosted.org/packages/b1/40/dd8f081f04a12912b65417979bf2097def0af0f20c89083ada3670562ac5/PyQt5_sip-12.9.0.tar.gz",
+                    "sha256": "d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "PyQt5-sip"
+                    }
+                }
+            ]
+        }
     ]
 }

--- a/pyqt/pyqt5.json
+++ b/pyqt/pyqt5.json
@@ -1,0 +1,65 @@
+{
+    "name": "pyqt5",
+    "config-opts": [
+        "--assume-shared",
+        "--concatenate",
+        "--confirm-license",
+        "--enable=QtCore",
+        "--enable=QtDBus",
+        "--enable=QtGui",
+        "--enable=QtNetwork",
+        "--enable=QtOpenGL",
+        "--enable=QtPrintSupport",
+        "--enable=QtQml",
+        "--enable=QtQuick",
+        "--enable=QtSql",
+        "--enable=QtTest",
+        "--enable=QtWebChannel",
+        "--enable=QtWidgets",
+        "--no-designer-plugin",
+        "--no-dist-info",
+        "--no-docstrings",
+        "--no-qml-plugin",
+        "--no-qsci-api",
+        "--no-stubs",
+        "--no-tools",
+        "QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.8/'",
+        "QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.8/'"
+    ],
+    "build-options": {
+        "arch": {
+            "aarch64": {
+                "config-opts": [
+                    "--disable-feature=PyQt_Desktop_OpenGL"
+                ]
+            }
+        }
+    },
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://pypi.python.org/packages/source/P/PyQt5/PyQt5-5.15.4.tar.gz",
+            "sha256": "2a69597e0dd11caabe75fae133feca66387819fc9bc050f547e5551bce97e5be",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "PyQt5"
+            }
+        },
+        {
+            "type": "script",
+            "commands": [
+                "processed=`sed -e 's|prefix|sysroot|' <<< $@`",
+                "python3 configure.py $processed"
+            ],
+            "dest-filename": "configure"
+        }
+    ],
+    "cleanup": [
+        "/share/sip"
+    ],
+    "modules": [
+        "../dbus-python/dbus-python.json",
+        "../python-opengl/python-opengl.json",
+        "sip.json"
+    ]
+}

--- a/pyqt/sip.json
+++ b/pyqt/sip.json
@@ -1,0 +1,32 @@
+{
+    "name": "sip4",
+    "config-opts": [
+        "--no-dist-info",
+        "--no-stubs",
+        "--bindir=/app/bin",
+        "--destdir=/app/lib/python3.8/site-packages",
+        "--incdir=/app/include",
+        "--pyidir=/app/lib/python3.8/site-packages",
+        "--sipdir=/app/share/sip",
+        "--sip-module PyQt5.sip"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.25/sip-4.19.25.tar.gz",
+            "sha256": "b39d93e937647807bac23579edbff25fe46d16213f708370072574ab1f1b4211"
+        },
+        {
+            "type": "script",
+            "commands": [
+                "processed=`sed -e 's|--prefix=/app||' <<< $@`",
+                "python3 configure.py $processed"
+            ],
+            "dest-filename": "configure"
+        }
+    ],
+    "cleanup": [
+        "/bin",
+        "/include"
+    ]
+}

--- a/pyqt/sip.json
+++ b/pyqt/sip.json
@@ -1,32 +1,78 @@
 {
-    "name": "sip4",
-    "config-opts": [
-        "--no-dist-info",
-        "--no-stubs",
-        "--bindir=/app/bin",
-        "--destdir=/app/lib/python3.8/site-packages",
-        "--incdir=/app/include",
-        "--pyidir=/app/lib/python3.8/site-packages",
-        "--sipdir=/app/share/sip",
-        "--sip-module PyQt5.sip"
+    "name": "sip",
+    "buildsystem": "simple",
+    "build-commands": [
+        "python setup.py build",
+        "python setup.py install --skip-build --prefix=/app --root=/ --optimize=1"
     ],
     "sources": [
         {
             "type": "archive",
-            "url": "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.25/sip-4.19.25.tar.gz",
-            "sha256": "b39d93e937647807bac23579edbff25fe46d16213f708370072574ab1f1b4211"
-        },
-        {
-            "type": "script",
-            "commands": [
-                "processed=`sed -e 's|--prefix=/app||' <<< $@`",
-                "python3 configure.py $processed"
-            ],
-            "dest-filename": "configure"
+            "url": "https://files.pythonhosted.org/packages/f8/b2/fcd5e964eefce0737512fb4ea263308769c671c3b1b9b1e380a5008ffef0/sip-6.1.1.tar.gz",
+            "sha256": "52d25af2fcd764c4e15cc9cd1350bdb0e63f52dfa2aa3c5e7679af7fde9f7e20",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "sip"
+            }
         }
     ],
     "cleanup": [
-        "/bin",
-        "/include"
+        "/bin"
+    ],
+    "modules": [
+        {
+            "name": "python-pyparsing",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyparsing\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz",
+                    "sha256": "c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "pyparsing"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python-packaging",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"packaging\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/86/3c/bcd09ec5df7123abcf695009221a52f90438d877a2f1499453c6938f5728/packaging-20.9.tar.gz",
+                    "sha256": "5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "packaging"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "python-toml",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"toml\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
+                    "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
+                    "x-checker-data": {
+                        "type": "pypi",
+                        "name": "toml"
+                    }
+                }
+            ]
+        }
     ]
 }

--- a/python-opengl/python-opengl.json
+++ b/python-opengl/python-opengl.json
@@ -1,0 +1,21 @@
+{
+    "name": "python-opengl",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyOpenGL\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b8/73/31c8177f3d236e9a5424f7267659c70ccea604dab0585bfcd55828397746/PyOpenGL-3.1.5.tar.gz",
+            "sha256": "4107ba0d0390da5766a08c242cf0cf3404c377ed293c5f6d701e457c57ba3424",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "PyOpenGL"
+            }
+        }
+    ],
+    "modules": [
+        "../freeglut/freeglut.json"
+    ]
+}


### PR DESCRIPTION
This adds version 5 of PyQt and PyQtWebEngine Python binding.  
I've been maintaining these modules in the qutebrowser packaging in the short period since I adopted that package, and it's I think it's better suited here.  
Calibre is an example of an app that can benefit from the PyQtWebEngine shared module, as correctly it uses the binary release and not building from source, so it's limited to x86_64.

Modules depend on the KDE 5.15 runtime.  
PyQtWebEngine also requires the [QtWebEngine base app](https://github.com/flathub/io.qt.qtwebengine.BaseApp/).

The following modules were also added as separated shared modules:

* freeglut
* python-opengl
* dbus-python

The following modules are packaged but were not separated into shared modules as they are build dependencies, are not needed on run time, used by the SIP buildsystem, so I kept them in the `sip.json` module. Removing these modules in the cleanup step will break applications that need them, so by default they must be packaged.

* python-packaging
* python-pyparsing

`x-checker-data` properties were added and `f-e-d-c` can update the modules when running on an app manifest.

For documentation purpose, I kept the commit that uses sip 4, if someone can't build with sip6 then sip4 is there in the commit history.

This was tested with qutebrowser and confirmed to build for x86_64 and aarch64 targets and run on x86_64 in flathub/org.qutebrowser.qutebrowser#54.

I haven't tried to enable every PyQt binding, I think I will leave it for a future PR when I'll have other apps to test with.