### PR TITLE
Fix SDL_ttf with freedesktop runtime 21.08

### DIFF
--- a/SDL/SDL_ttf-2.0.11.json
+++ b/SDL/SDL_ttf-2.0.11.json
@@ -2,6 +2,9 @@
     "name": "SDL_ttf",
     "config-opts": ["--disable-static"],
     "rm-configure": true,
+    "config-opts": [
+        "ac_cv_path_FREETYPE_CONFIG=pkg-config freetype2"
+    ],
     "sources": [
         {
             "type": "archive",


### PR DESCRIPTION
The program **freetype-config** is deprecated and was removed in the runtime.
This patch missuses the `ac_cv_path_FREETYPE_CONFIG` cache variable to prevent Autoconf from searching for **freetype-config** and use `pkg-config freetype2` instead.