### PR TITLE
Fix smpeg with freedesktop runtime 21.08

### DIFF
--- a/smpeg/smpeg-0.4.5.json
+++ b/smpeg/smpeg-0.4.5.json
@@ -13,6 +13,12 @@
             "sha256": "1276ea797dd9fde8a12dd3f33f180153922544c28ca9fc7b477c018876be1916"
         },
         {
+            "type": "shell",
+            "commands": [
+                "sed -i '/^## libtool.m4/,/^#####/d' acinclude.m4"
+            ]
+        },
+        {
             "type": "script",
             "dest-filename": "autogen.sh",
             "commands": [


### PR DESCRIPTION
The file **acinclude.m4** contains an old version of **libtool.m4** which causes the following error:

> Version mismatch error.  This is libtool 2.4.6, but the definition of this LT_INIT comes from an older release.
> You should recreate aclocal.m4 with macros from libtool 2.4.6 and run autoconf again.

This patch removes the old version, which in turn causes **autoreconf** to install a new version by running **libtoolize**.