### PR TITLE
Updated ladspa to 1.17 since the old version doesn't exist for download

### DIFF
--- a/linux-audio/ladspa.json
+++ b/linux-audio/ladspa.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "http://www.ladspa.org/download/ladspa_sdk_1.15.tgz",
-            "sha256": "4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded"
+            "url": "http://www.ladspa.org/download/ladspa_sdk_1.17.tgz",
+            "sha256": "d9d596171d93f9c226fcdb7e27c6f917422ac487efe2c05e0a18094df4268061"
         }
     ]
 }


### PR DESCRIPTION
The official site has a link only for the 1.17 version right now.
http://www.ladspa.org/download/