### PR TITLE
qt4: fix compilation with Freedesktop 21.08 runtime

### DIFF
--- a/qt4/fixgcc11.patch
+++ b/qt4/fixgcc11.patch
@@ -1,0 +1,11 @@
+--- a/tools/linguist/linguist/messagemodel.cpp    2021-06-07 12:18:43.713434493 +0200
++++ b/tools/linguist/linguist/messagemodel.cpp    2021-06-07 12:24:24.828016548 +0200
+@@ -183,7 +183,7 @@
+         if (ContextItem *c = one->findContext(oc->context())) {
+             for (int j = 0; j < oc->messageCount(); ++j) {
+                 MessageItem *m = oc->messageItem(j);
+-                if (c->findMessage(m->text(), m->comment()) >= 0)
++                if (c->findMessage(m->text(), m->comment()))
+                     ++inBoth;
+             }
+         }

--- a/qt4/qt4-4.8.7-minimal.json
+++ b/qt4/qt4-4.8.7-minimal.json
@@ -81,6 +81,10 @@
             "path": "fixgcc9.patch"
         },
         {
+            "type": "patch",
+            "path": "fixgcc11.patch"
+        },
+        {
             "type": "shell",
             "commands": [
                 "sed -i \"s|-O2|${CXXFLAGS}|\" mkspecs/common/{g++,gcc}-base.conf",


### PR DESCRIPTION
Add a patch to build the module with GCC11. Credits go to the maintainer of the AUR package.
