### PR TITLE
mac: update to 7.14

### DIFF
--- a/mac/mac.json
+++ b/mac/mac.json
@@ -1,9 +1,9 @@
 {
   "name": "libmac",
-  "buildsystem": "simple",
-  "build-commands": [
-    "make -f Source/Projects/NonWindows/Makefile -j $FLATPAK_BUILDER_N_JOBS",
-    "make -f Source/Projects/NonWindows/Makefile prefix=/app install"
+  "subdir": "Source/Projects/NonWindows",
+  "no-autogen": true,
+  "make-install-args": [
+    "prefix=/app"
   ],
   "cleanup": [
     "/include/MAC"
@@ -11,8 +11,8 @@
   "sources": [
     {
         "type": "archive",
-        "url": "https://freac.org/patches/MAC_SDK_629.zip",
-        "sha256": "af62c05d83c003c3af8772c01ca8796b8f2ac75a2f5ce1af183ab021cd7f3cf0",
+        "url": "https://freac.org/patches/MAC_SDK_714.zip",
+        "sha256": "42b35472d8fb5704f694229399615069d155b5e13b8652ad922667845dbb2a96",
         "strip-components": 0
     }
   ]


### PR DESCRIPTION
Update the Monkey's Audio codec to the latest version.

Upstream has integrated Makefile adjustments, so I was able to simplify build instructions again as discussed in #144.