### PR TITLE
Make with only one job on libappindicator.

### DIFF
--- a/libappindicator/libappindicator-gtk2-12.10.json
+++ b/libappindicator/libappindicator-gtk2-12.10.json
@@ -1,7 +1,8 @@
 {
   "name": "libappindicator",
   "build-options": {
-    "cflags": "-Wno-error"
+    "cflags": "-Wno-error",
+    "make-args": [ "-j1" ]
   },
   "rm-configure": true,
   "config-opts": [

--- a/libappindicator/libappindicator-gtk3-12.10.json
+++ b/libappindicator/libappindicator-gtk3-12.10.json
@@ -1,7 +1,8 @@
 {
   "name": "libappindicator",
   "build-options": {
-    "cflags": "-Wno-error"
+    "cflags": "-Wno-error",
+    "make-args": [ "-j1" ]
   },
   "rm-configure": true,
   "config-opts": [

--- a/libappindicator/libappindicator-gtk3-introspection-12.10.json
+++ b/libappindicator/libappindicator-gtk3-introspection-12.10.json
@@ -1,7 +1,8 @@
 {
   "name": "libappindicator",
   "build-options": {
-    "cflags": "-Wno-error"
+    "cflags": "-Wno-error",
+    "make-args": [ "-j1" ]
   },
   "rm-configure": true,
   "config-opts": [

--- a/libappindicator/libappindicator.json.in
+++ b/libappindicator/libappindicator.json.in
@@ -1,7 +1,8 @@
 {
   "name": "libappindicator",
   "build-options": {
-    "cflags": "-Wno-error"
+    "cflags": "-Wno-error",
+    "make-args": [ "-j1" ]
   },
   "rm-configure": true,
   "config-opts": [


### PR DESCRIPTION
Hi, all. I made a PR to an application that uses libappindicator, and the bot build failed. @ebassi on Matrix determined the cause of the build failure to be a parallelization issue within libappindicator. As the library is unlikely to see any real changes to properly fix that, this PR works around it by building the module without parallelization with `make -j1`.