### PR TITLE
Add SDL_gfx module

### DIFF
--- a/SDL/SDL_gfx-2.0.25.json
+++ b/SDL/SDL_gfx-2.0.25.json
@@ -1,0 +1,24 @@
+{
+    "name": "SDL_gfx",
+    "config-opts": [
+        "--disable-static"
+    ],
+    "build-options": {
+        "arch": {
+            "aarch64": {
+                "//": "Code assumes that if __GNUC__ is defined and MMX is enabled, then x86-specific mmintrin.h is available",
+                "config-opts": [
+                    "--disable-static",
+                    "--disable-mmx"
+                ]
+            }
+        }
+    },
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://downloads.sourceforge.net/project/sdlgfx/SDL_gfx-2.0.25.tar.gz",
+            "sha256": "556eedc06b6cf29eb495b6d27f2dcc51bf909ad82389ba2fa7bdc4dec89059c0"
+        }
+    ]
+}


### PR DESCRIPTION
This requires special care and feeding to build on aarch64, which I
borrowed from org.manaplus.ManaPlus when org.tuxpaint.Tuxpaint gained a
dependency on this library.

I suspect (without proof) that this library is one of the reasons that
the other existing user of SDL_gfx on Flathub,
com.roguetemple.HyperRogue, is not built for aarch64.
