### PR TITLE
Add Vorbisgain

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,3 +16,4 @@
 /mac/              @enzo1982 @Eonfge
 /pygtk/            @Eonfge
 /gzdoom/           @Eonfge
+/vobisgain/        @Eonfge

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,4 +16,4 @@
 /mac/              @enzo1982 @Eonfge
 /pygtk/            @Eonfge
 /gzdoom/           @Eonfge
-/vobisgain/        @Eonfge
+/vorbisgain/       @Eonfge

--- a/vorbisgain/0001-temp_files.patch
+++ b/vorbisgain/0001-temp_files.patch
@@ -1,0 +1,75 @@
+Description: Apply patch to use temp files, which are dependent
+ on the file which is beeing processed, instead always using the same
+ filename, which can result to data loss in scenarios where two or more
+ vorbis processes are running parallel.
+Author: Pavel N. Krivitsky <pavel@krivitsky.name>
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=505164
+Forwarded: no
+---
+ vorbis.c |   17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+--- a/vorbis.c
++++ b/vorbis.c
+@@ -56,7 +56,7 @@
+ #define PROGRESS_FORMAT_SIZE 8
+ #define MIN_FILENAME_SIZE 5
+ #define MIN_MIDDLE_TRUNCATE_SIZE 20
+-#define TEMP_NAME "vorbisgain.tmpXXXXXX"
++#define TEMP_EXT ".vgain.tmpXXXXXX"
+ 
+ 
+ /**
+@@ -684,11 +684,10 @@
+         }
+     }
+ 
+-    /* Make sure temp is in same folder as file. And yes, the malloc is larger
+-     * than necessary (and not always needed). Lets keep it simple though (at
+-     * the expense of a few bytes)...
++    /* Construct a temporary file name by appending TEMP_EXT to
++     * the name of the file being modified.
+      */
+-    temp_name = malloc(strlen(filename) + sizeof(TEMP_NAME));
++    temp_name = malloc(strlen(filename)*sizeof(char) + sizeof(TEMP_EXT));
+ 
+     if (temp_name == NULL)
+     {
+@@ -697,7 +696,7 @@
+     }
+ 
+     strcpy(temp_name, filename);
+-    strcpy((char *) last_path(temp_name), TEMP_NAME);
++    strcat(temp_name, TEMP_EXT);
+ 
+ #ifdef WIN32
+     temp_name = _mktemp(temp_name);
+@@ -779,6 +778,7 @@
+         file_error(_("Note: Couldn't set mode for file '%s': "), filename);
+     }
+ 
++#if 0 /* Disable for Debian, this surprises people and is not useful --liw */
+     utime_buf.actime = stat_buf.st_atime;
+     utime_buf.modtime = stat_buf.st_mtime;
+ 
+@@ -786,6 +786,7 @@
+     {
+         file_error(_("Note: Couldn't set time for file '%s': "), filename);
+     }
++#endif
+ 
+     result = 0;
+ 
+@@ -817,10 +818,10 @@
+ 
+     if (delete_temp)
+     {
+-        if (remove(TEMP_NAME) != 0)
++        if (remove(temp_name) != 0)
+         {
+             file_error(_("Note: Couldn't remove temporary file '%s': "), 
+-                TEMP_NAME);
++                temp_name);
+         }
+     }
+ 

--- a/vorbisgain/0002-errno.patch
+++ b/vorbisgain/0002-errno.patch
@@ -1,0 +1,33 @@
+Description: Zero errno before readdir call.
+From: http://bugs.debian.org/375110
+Forwarded: no
+---
+ recurse.c |    3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/recurse.c
++++ b/recurse.c
+@@ -408,6 +408,7 @@
+  */
+ static int read_dir(DIRECTORY *directory)
+ {
++    errno = 0;
+     directory->entry = readdir(directory->dir);
+ 
+     if (directory->entry != NULL)
+@@ -622,6 +623,7 @@
+     /* Check for wildcards */
+     settings->pattern = last_path(my_path);
+ 
++#if 0 /* Disable for Debian, as it suprises people. --liw */
+     if (contains_pattern(settings->pattern))
+     {
+         /* Strip last part of path */
+@@ -637,6 +639,7 @@
+         }
+     }
+     else
++#endif
+     {
+         settings->pattern = NULL;
+     }

--- a/vorbisgain/0003-manpage.patch
+++ b/vorbisgain/0003-manpage.patch
@@ -1,0 +1,248 @@
+Description: Man page says --silent, should be --skip
+From: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=355783
+Forwarded: no
+---
+ vorbisgain.1 |   60 ++++++++++++-----------------------------------------------
+ 1 file changed, 13 insertions(+), 47 deletions(-)
+
+--- a/vorbisgain.1
++++ b/vorbisgain.1
+@@ -2,10 +2,8 @@
+ .\" groff -man -Tascii vorbisgain.1
+ .\"
+ .TH vorbisgain 1 "2004 Jan 3" "" "VorbisGain"
+-
+ .SH NAME
+ vorbisgain \- calculate the replay gain for Ogg Vorbis files
+-
+ .SH SYNOPSIS
+ .B vorbisgain
+ [
+@@ -16,7 +14,6 @@
+ .I album gain
+ ]
+ .I input_files \fR...
+-
+ .SH DESCRIPTION
+ .B vorbisgain
+ calculates the ReplayGain values for the named Ogg Vorbis input files and
+@@ -27,7 +24,6 @@
+ uses a default target level of 89 dB, rather than the 83 dB recommended by the
+ ReplayGain standard, when calculating the gain to apply. (Some players include
+ a pre-amplification setting with which the target level can be changed.)
+-
+ .PP
+ .B vorbisgain
+ input files must be Ogg Vorbis I files with 1 or 2 channels and a sample rate
+@@ -35,21 +31,16 @@
+ kHz. If an input file contains multiple streams (i.e., it is chained), the
+ streams must all have the same format, in terms of sampling frequency and
+ number of channels.
+-
+ .PP
+ All streams in a chained file are processed, but the ReplayGain tags are
+ only written to (or removed from) the first stream.
+-
+ .SH OPTIONS
+-
+ .IP "-h, --help"
+ Show command help.
+-
+ .IP "-a, --album"
+ Activates album mode, in which the album gain (sometimes called the audiophile
+ gain) is calculated in addition to the track gain (sometimes called the radio
+ gain).
+-
+ .IP "-g n, --album-gain=n"
+ Sets the album gain value to use. Default is to calculate it, if
+ .I -a
+@@ -59,38 +50,31 @@
+ dB, specifying the
+ .B change
+ in volume that should be applied.
+-
+ .IP "-c, --clean"
+ Remove any ReplayGain tags from the specified files. If a file does not
+ contain any ReplayGain tags, the file is not modified.
+-
+ .IP "-C, --convert"
+ Convert old format ReplayGain tags to a new format (see section TAG FORMAT
+ below for details). If a file does not contain all ReplayGain tags that are
+ needed for a conversion, the file is not modified. The album peak tag is
+ only created if
+ .I -a
+-is specified, and the album gain value is then checked for concistency.
++is specified, and the album gain value is then checked for consistency.
+ Otherwise any album gain is converted without any checks.
+-
+ .IP "-d, --display-only"
+ Display the result only; do not write anything to disk. This applies to all
+ options.
+-
+ .IP "-f, --fast"
+ Only calculate the gain for files that do not contain all replay gain tags
+ needed (the album gain and peak tags are only considered if
+ .I -a
+ has been specified).
+-
+ .IP "-n, --no-progress"
+ Only display results, but don't show progress in percentages and times. This
+ can be useful if the output is piped into other programs.
+-
+ .IP "-q, --quiet"
+ Do not display any output while processing. Only error and warning messages will
+ be printed.
+-
+ .IP "-r, --recursive"
+ Enter directories (recursively) and search for files, if directories or file
+ patterns are specified.
+@@ -98,65 +82,51 @@
+ Only available if
+ .B vorbisgain
+ was configured with --enable-recursive.
+-
+-.IP "-s, --silent"
+-Sliently skip any non-Vorbis files found. Vorbis files that can't be processed
++.IP "-s, --skip"
++Silently skip any non-Vorbis files found. Vorbis files that can't be processed
+ for some reason are skipped as well, though not silently. Default is to stop
+ when such files are encountered.
+-
+ .IP "-v, --version"
+ Display the version of the program.
+-
+ .SH EXAMPLES
+-
+ Simplest version. Calculate the track gain and peak only.
+ .PP
+ .RS
+ vorbisgain somefile.ogg
+ .RE
+-
+ .PP
+ Note that the following examples are only possible if
+ .B vorbisgain
+ was configured with --enable-recursive.
+-
+ .PP
+ Calculate the album gain and peak, in addition to the track gain and peak, for
+ all .ogg files in the directory "music" (and all subdirectories). All files in
+ one directory are treated as belonging to the same album. Files that already
+ have ReplayGain tags are not re-calculated. Note the quotes, as they cause the
+ shell to not do any filename globbing:
+-
+ .PP
+ .RS
+ vorbisgain -a -f -r "music/*.ogg"
+ .RE
+-
+ .PP
+ Calculate the album gain. The files specified before the directory "album"
+ are treated as one album, the files in the directory "album" as another
+ album and the remaining files as a third album:
+-
+ .PP
+ .RS
+ vorbisgain -a -r a.ogg b.ogg c.ogg album d.ogg e.ogg f.ogg
+ .RE
+-
+ .PP
+ Remove all replaygain tags from a collection of oggs:
+-
+ .PP
+ .RS
+ vorbisgain -c -r "music/*.ogg"
+ .RE
+-
+ .SH TAG FORMAT
+-
+ .B vorbisgain
+ creates tags like these (when in
+ .I -a
+ mode):
+-
+ .PP
+ .RS
+ REPLAYGAIN_TRACK_GAIN=-7.03 dB
+@@ -170,18 +140,15 @@
+ .RS
+ REPLAYGAIN_ALBUM_PEAK=1.21822226
+ .RE
+-
+ .PP
+ Gain specifies how much the volume should be changed before playback, in dB.
+ Peak is the maximum sample value of the file before any gain has been
+ applied, where 1.0 means "full sample value" (32,767 when decoding to signed
+ 16 bit samples).
+-
+ .PP
+ Earlier versions of
+ .B vorbisgain
+ (before 0.30) created the following tags:
+-
+ .PP
+ .RS
+ RG_RADIO
+@@ -192,7 +159,6 @@
+ .RS
+ RG_AUDIOPHILE
+ .RE
+-
+ .PP
+ When
+ .I -c
+@@ -200,44 +166,44 @@
+ REPLAYGAIN_TRACK_PEAK, RG_AUDIOPHILE to REPLAYGAIN_ALBUM_GAIN and
+ REPLAYGAIN_ALBUM_PEAK is calculated as the maximum of all RG_PEAK tags in
+ the album.
+-
+ .SH AUTHORS
+-
+ .TP
+ Program Code:
+ .br
+ Gian-Carlo Pascutto <gcp@sjeng.org>
+ .br
+ Magnus Holmgren <lear@algonet.se>
+-
+ .TP
+ ReplayGain Analysis Code:
+ .br
+ Glen Sawyer <glensawyer@hotmail.com>
+ .br
+ Frank Klemm (http://www.uni-jena.de/~pfk/)
+-
+ .TP
+ Man Page:
+ .br
+ Magnus Holmgren <lear@algonet.se>
+-
+ .SH BUGS
+-
+ None known.
+-
+ .SH SEE ALSO
+-
+ .TP
+ http://sjeng.org/vorbisgain.html
+ Home page for VorbisGain. The latest version, and a Windows executable,
+ can be found here.
+-
+ .TP
+ http://www.replaygain.org/
+ Contains detailed information about ReplayGain and how it is calculated.
+-
+ .TP
+ http://www.hydrogenaudio.org/
+ Discussion forum for audio compression and related issues, including Ogg
+ Vorbis and VorbisGain.
++.SH NOTE
++The version of vorbisgain packaged for Debian differs in two ways from
++the upstream version. First, it does not retain the modification time
++of the input file: if tags are changed in a file, the mtime will change.
++Second, it does not try to process wildcards in filenames. This makes
++it impossible to say "process all foo*.ogg in all subdirectories", but
++also avoids problems with filenames that actually contain wildcards.
++Without this change, "vorbisgain *.ogg" in a directory with a file that
++contains a question mark would result in that file being treated as
++being in a different album.

--- a/vorbisgain/0004-vorbisgain_mtime.patch
+++ b/vorbisgain/0004-vorbisgain_mtime.patch
@@ -1,0 +1,183 @@
+Description: When a file's metadata is updated, the mtime is changed
+ to the current time. Whether this is correct or not is often a
+ religious issue (metadata-vs-data), but, generally, all other
+ tag-editing software choose to keep the timestamp.
+ .
+ Since the upstream fixed the issue, it is bad to ignore the fix
+ altogether. At the very least, there should be a command-line
+ option to follow the upstream and The Only Right(tm) behaviour.
+Author: Adam Borowski <kilobyte@angband.pl>
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=445958
+---
+ vorbis.c     |   18 ++++++++++--------
+ vorbis.h     |    2 +-
+ vorbisgain.1 |    7 ++++++-
+ vorbisgain.c |   20 ++++++++++++++------
+ vorbisgain.h |    1 +
+ 5 files changed, 32 insertions(+), 16 deletions(-)
+
+--- a/vorbis.c
++++ b/vorbis.c
+@@ -557,7 +557,8 @@
+  *         message has been printed).
+  */
+ int write_gains(const char *filename, float track_peak, float track_gain,
+-    float album_peak, float album_gain, int verbose, int remove_tags)
++    float album_peak, float album_gain, int verbose, int remove_tags,
++    SETTINGS* settings)
+ {
+     struct stat stat_buf;
+     struct utimbuf utime_buf;
+@@ -778,15 +779,16 @@
+         file_error(_("Note: Couldn't set mode for file '%s': "), filename);
+     }
+ 
+-#if 0 /* Disable for Debian, this surprises people and is not useful --liw */
+-    utime_buf.actime = stat_buf.st_atime;
+-    utime_buf.modtime = stat_buf.st_mtime;
+-
+-    if (utime(filename, &utime_buf) != 0)
++    if (!settings->trample_mtime)
+     {
+-        file_error(_("Note: Couldn't set time for file '%s': "), filename);
++        utime_buf.actime = stat_buf.st_atime;
++        utime_buf.modtime = stat_buf.st_mtime;
++
++        if (utime(filename, &utime_buf) != 0)
++        {
++            file_error(_("Note: Couldn't set time for file '%s': "), filename);
++        }
+     }
+-#endif
+ 
+     result = 0;
+ 
+--- a/vorbisgain.1
++++ b/vorbisgain.1
+@@ -72,6 +72,10 @@
+ .IP "-n, --no-progress"
+ Only display results, but don't show progress in percentages and times. This
+ can be useful if the output is piped into other programs.
++.IP "-p, --preserve-mtime"
++Do not trample upon the timestamps of any files being worked on.  This obeys
++the expected data-vs-metadata behaviour, but can confuse some naive
++archivers.
+ .IP "-q, --quiet"
+ Do not display any output while processing. Only error and warning messages will
+ be printed.
+@@ -200,7 +204,8 @@
+ .SH NOTE
+ The version of vorbisgain packaged for Debian differs in two ways from
+ the upstream version. First, it does not retain the modification time
+-of the input file: if tags are changed in a file, the mtime will change.
++of the input file by default: if tags are changed in a file, the mtime will
++change; you can specify "-p" to get the normal behaviour.
+ Second, it does not try to process wildcards in filenames. This makes
+ it impossible to say "process all foo*.ogg in all subdirectories", but
+ also avoids problems with filenames that actually contain wildcards.
+--- a/vorbisgain.c
++++ b/vorbisgain.c
+@@ -235,7 +235,7 @@
+         {
+             if (write_gains(file->filename, file->track_peak, 
+                 file->track_gain, album_peak, file->album_gain, 
+-                !settings->quiet, 0) < 0)
++                !settings->quiet, 0, settings) < 0)
+             {
+                 return -1;
+             }
+@@ -288,7 +288,7 @@
+             else
+             {
+                 if (write_gains(file->filename, NO_PEAK, NO_GAIN, 
+-                    NO_PEAK, NO_GAIN, !settings->quiet, 1) < 0)
++                    NO_PEAK, NO_GAIN, !settings->quiet, 1, settings) < 0)
+                 {
+                     return -1;
+                 }
+@@ -425,7 +425,8 @@
+             if (!settings->album)
+             {
+                 if (!settings->display_only && write_gains(file->filename,
+-                    file->track_peak, file->track_gain, NO_PEAK, NO_GAIN, 0, 0) < 0)
++                    file->track_peak, file->track_gain, NO_PEAK, NO_GAIN, 0, 0,
++                    settings) < 0)
+                 {
+                     return -1;
+                 }
+@@ -466,7 +467,7 @@
+ 
+                 if (write_gains(file->filename, file->track_peak,
+                     file->track_gain, album_peak, album_gain,
+-                    !settings->quiet, 0) < 0)
++                    !settings->quiet, 0, settings) < 0)
+                 {
+                     return -1;
+                 }
+@@ -497,6 +498,7 @@
+     fprintf(stderr, _("  -h, --help           Print this help text\n"));
+     fprintf(stderr, _("  -n, --no-progress    Don't show progress, just print results\n"));
+     fprintf(stderr, _("  -q, --quiet          Don't print any output (except errors)\n"));
++    fprintf(stderr, _("  -p, --preserve-mtime Don't change the timestamps\n"));
+ #ifdef ENABLE_RECURSIVE
+     fprintf(stderr, _("  -r, --recursive      Search for files recursivly, each folder as an album\n"));
+ #endif
+@@ -522,6 +524,7 @@
+     {"fast",         0, NULL, 'f'},
+     {"help",         0, NULL, 'h'},
+     {"no-progress",  0, NULL, 'n'},
++    {"preserve-mtime",0,NULL, 'p'},
+     {"quiet",        0, NULL, 'q'},
+ #ifdef ENABLE_RECURSIVE
+     {"recursive",    0, NULL, 'r'},
+@@ -533,9 +536,9 @@
+ 
+ 
+ #ifdef ENABLE_RECURSIVE
+-#define ARG_STRING "acCdfg:hnqrst:v"
++#define ARG_STRING "acCdfg:hnpqrst:v"
+ #else
+-#define ARG_STRING "acCdfg:hnqst:v"
++#define ARG_STRING "acCdfg:hnpqst:v"
+ #endif
+ 
+ 
+@@ -549,6 +552,7 @@
+     memset(&settings, 0, sizeof(settings));
+     settings.first_file = 1;
+     settings.album_gain = NO_GAIN;
++    settings.trample_mtime = 1;
+     settings.show_progress = 1;
+ 
+ #ifdef WIN32
+@@ -623,6 +627,10 @@
+ 	  settings.show_progress = 0;
+ 	  break;
+ 
++        case 'p':
++            settings.trample_mtime = 0;
++            break;
++
+         case 'q':
+             settings.quiet = 1;
+             break;
+--- a/vorbisgain.h
++++ b/vorbisgain.h
+@@ -31,6 +31,7 @@
+     int convert;            /**< Convert old format tags to new format */
+     int display_only;
+     int fast;               /**< Skip files that already have all needed tags */
++    int trample_mtime;
+     int quiet;
+ #ifdef ENABLE_RECURSIVE
+     int recursive;
+--- a/vorbis.h
++++ b/vorbis.h
+@@ -15,6 +15,6 @@
+     SETTINGS *settings);
+ extern int write_gains(const char *filename, float track_peak, 
+     float track_gain, float album_gain, float album_peak, int verbose, 
+-    int remove_tags);
++    int remove_tags, SETTINGS *settings);
+ 
+ #endif /* VG_VORBIS_H */

--- a/vorbisgain/0005-double_fclose.patch
+++ b/vorbisgain/0005-double_fclose.patch
@@ -1,0 +1,21 @@
+Description: Don't call fclose() twice.
+Author: Jonathan Neuschäfer <j.neuschaefer@gmx.net>
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=632947
+---
+ vorbis.c |    5 -----
+ 1 file changed, 5 deletions(-)
+
+--- a/vorbis.c
++++ b/vorbis.c
+@@ -813,11 +813,6 @@
+         fclose(infile);
+     }
+ 
+-    if (infile != NULL)
+-    {
+-        fclose(infile);
+-    }
+-
+     if (delete_temp)
+     {
+         if (remove(temp_name) != 0)

--- a/vorbisgain/0006-manpage_hyphens.patch
+++ b/vorbisgain/0006-manpage_hyphens.patch
@@ -1,0 +1,56 @@
+Description: Resolved hyphen-used-as-minus-sign lintian complaints.
+Forwarded: no
+--- a/vorbisgain.1
++++ b/vorbisgain.1
+@@ -85,7 +85,7 @@
+ .I Note:
+ Only available if
+ .B vorbisgain
+-was configured with --enable-recursive.
++was configured with \-\-enable\-recursive.
+ .IP "-s, --skip"
+ Silently skip any non-Vorbis files found. Vorbis files that can't be processed
+ for some reason are skipped as well, though not silently. Default is to stop
+@@ -101,7 +101,7 @@
+ .PP
+ Note that the following examples are only possible if
+ .B vorbisgain
+-was configured with --enable-recursive.
++was configured with \-\-enable\-recursive.
+ .PP
+ Calculate the album gain and peak, in addition to the track gain and peak, for
+ all .ogg files in the directory "music" (and all subdirectories). All files in
+@@ -110,7 +110,7 @@
+ shell to not do any filename globbing:
+ .PP
+ .RS
+-vorbisgain -a -f -r "music/*.ogg"
++vorbisgain \-a \-f \-r "music/*.ogg"
+ .RE
+ .PP
+ Calculate the album gain. The files specified before the directory "album"
+@@ -118,13 +118,13 @@
+ album and the remaining files as a third album:
+ .PP
+ .RS
+-vorbisgain -a -r a.ogg b.ogg c.ogg album d.ogg e.ogg f.ogg
++vorbisgain \-a \-r a.ogg b.ogg c.ogg album d.ogg e.ogg f.ogg
+ .RE
+ .PP
+ Remove all replaygain tags from a collection of oggs:
+ .PP
+ .RS
+-vorbisgain -c -r "music/*.ogg"
++vorbisgain \-c \-r "music/*.ogg"
+ .RE
+ .SH TAG FORMAT
+ .B vorbisgain
+@@ -205,7 +205,7 @@
+ The version of vorbisgain packaged for Debian differs in two ways from
+ the upstream version. First, it does not retain the modification time
+ of the input file by default: if tags are changed in a file, the mtime will
+-change; you can specify "-p" to get the normal behaviour.
++change; you can specify "\-p" to get the normal behaviour.
+ Second, it does not try to process wildcards in filenames. This makes
+ it impossible to say "process all foo*.ogg in all subdirectories", but
+ also avoids problems with filenames that actually contain wildcards.

--- a/vorbisgain/0007-recursively_spelling.patch
+++ b/vorbisgain/0007-recursively_spelling.patch
@@ -1,0 +1,14 @@
+Description: "recursivly" should be spelled "recursively". Thanks Adam.
+From: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=661999
+Forwarded: no
+--- a/vorbisgain.c
++++ b/vorbisgain.c
+@@ -500,7 +500,7 @@
+     fprintf(stderr, _("  -q, --quiet          Don't print any output (except errors)\n"));
+     fprintf(stderr, _("  -p, --preserve-mtime Don't change the timestamps\n"));
+ #ifdef ENABLE_RECURSIVE
+-    fprintf(stderr, _("  -r, --recursive      Search for files recursivly, each folder as an album\n"));
++    fprintf(stderr, _("  -r, --recursive      Search for files recursively, each folder as an album\n"));
+ #endif
+     fprintf(stderr, _("  -s, --skip           Skip non-Vorbis or faulty files\n"));
+     fprintf(stderr, _("  -v, --version        Display version number and exit\n\n"));

--- a/vorbisgain/0008-manpage_recursion_mistake.patch
+++ b/vorbisgain/0008-manpage_recursion_mistake.patch
@@ -1,0 +1,23 @@
+Description: The manpage shows methods that don't work. They have been replaced.
+From: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=447402
+Forwarded: no
+--- a/vorbisgain.1
++++ b/vorbisgain.1
+@@ -110,7 +110,7 @@
+ shell to not do any filename globbing:
+ .PP
+ .RS
+-vorbisgain \-a \-f \-r "music/*.ogg"
++vorbisgain \-a \-f \-r music/
+ .RE
+ .PP
+ Calculate the album gain. The files specified before the directory "album"
+@@ -124,7 +124,7 @@
+ Remove all replaygain tags from a collection of oggs:
+ .PP
+ .RS
+-vorbisgain \-c \-r "music/*.ogg"
++vorbisgain \-c \-r music/
+ .RE
+ .SH TAG FORMAT
+ .B vorbisgain

--- a/vorbisgain/0009-hardening.patch
+++ b/vorbisgain/0009-hardening.patch
@@ -1,0 +1,13 @@
+Description: Allow build with dh compat level 9 (debian build flags)
+Forwarded: no
+--- a/misc.c
++++ b/misc.c
+@@ -56,7 +56,7 @@
+     vfprintf(stderr, message, args);
+     va_end(args);
+ 
+-    fprintf(stderr, strerror(err_num));
++    fputs(strerror(err_num), stderr);
+     fprintf(stderr, "\n");
+ }
+ 

--- a/vorbisgain/0010-fclose.patch
+++ b/vorbisgain/0010-fclose.patch
@@ -1,0 +1,13 @@
+Solve "too many open files" by closing those which are not compatible with vorbisgain. Thanks to Marcel Rehberg for the patch.
+--- a/vorbis.c
++++ b/vorbis.c
+@@ -357,7 +357,8 @@
+         {
+ 	        vorbis_error(result, _("Couldn't process '%s': "), filename);
+         }
+-
++        // make sure file is closed, since ov_open failed we are still responsible
++        fclose(file);
+         return -1;
+     }
+ 

--- a/vorbisgain/README.md
+++ b/vorbisgain/README.md
@@ -1,0 +1,23 @@
+Vorbisgain comes in two version;
+- The main source: https://sjeng.org/ftp/vorbis/
+- The Debian version: http://deb.debian.org/debian/pool/main/v/vorbisgain/
+
+The catch is... Debian has 10 patches:
+- 0001-temp_files.patch
+- 0002-errno.patch
+- 0003-manpage.patch
+- 0004-vorbisgain_mtime.patch
+- 0005-double_fclose.patch
+- 0006-manpage_hyphens.patch
+- 0007-recursively_spelling.patch
+- 0008-manpage_recursion_mistake.patch
+- 0009-hardening.patch
+- 0010-fclose.patch
+
+Of particular concern are 0005, 0009 and 0010 which might have implications for memory-leaks and string inputs.
+
+## Other points of concern
+
+https://pkgs.org/download/vorbisgain
+
+Lots of distributions don't include these patches as well, but I prefer to stick with the tried and tested package from Debian.

--- a/vorbisgain/vorbisgain_0.37-2.json
+++ b/vorbisgain/vorbisgain_0.37-2.json
@@ -1,0 +1,51 @@
+{
+    "name": "vorbisgain",
+    "buildsystem": "autotools",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "http://deb.debian.org/debian/pool/main/v/vorbisgain/vorbisgain_0.37.orig.tar.gz",
+            "sha256": "dd6db051cad972bcac25d47b4a9e40e217bb548a1f16328eddbb4e66613530ec"
+        },
+        {
+            "type": "patch",
+            "path": "0001-temp_files.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0002-errno.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0003-manpage.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0004-vorbisgain_mtime.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0005-double_fclose.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0006-manpage_hyphens.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0007-recursively_spelling.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0008-manpage_recursion_mistake.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0009-hardening.patch"
+        },
+        {
+            "type": "patch",
+            "path": "0010-fclose.patch"
+        }
+    ]
+}

--- a/vorbisgain/vorbisgain_0.37-2.json
+++ b/vorbisgain/vorbisgain_0.37-2.json
@@ -1,6 +1,9 @@
 {
     "name": "vorbisgain",
     "buildsystem": "autotools",
+    "cleanup": [
+        "/man"
+    ],
     "sources": [
         {
             "type": "archive",

--- a/vorbisgain/vorbisgain_0.37-2.json
+++ b/vorbisgain/vorbisgain_0.37-2.json
@@ -12,43 +12,18 @@
         },
         {
             "type": "patch",
-            "path": "0001-temp_files.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0002-errno.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0003-manpage.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0004-vorbisgain_mtime.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0005-double_fclose.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0006-manpage_hyphens.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0007-recursively_spelling.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0008-manpage_recursion_mistake.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0009-hardening.patch"
-        },
-        {
-            "type": "patch",
-            "path": "0010-fclose.patch"
+            "paths": [
+                "0001-temp_files.patch",
+                "0002-errno.patch",
+                "0003-manpage.patch",
+                "0004-vorbisgain_mtime.patch",
+                "0005-double_fclose.patch",
+                "0006-manpage_hyphens.patch",
+                "0007-recursively_spelling.patch",
+                "0008-manpage_recursion_mistake.patch",
+                "0009-hardening.patch",
+                "0010-fclose.patch"
+            ]
         }
     ]
 }


### PR DESCRIPTION
From a reliability point-of-view, we should really ensure that all packages using Vorbisgain adopt this shared module, which has all the patches from Debian. Upsteam doesn't seem to be working on it any longer.