### PR TITLE
Add pyqt5

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,3 +17,4 @@
 /pygtk/            @Eonfge
 /gzdoom/           @Eonfge
 /vorbisgain/       @Eonfge
+/pyqt5/            @catsout

--- a/pyqt5/README.md
+++ b/pyqt5/README.md
@@ -1,0 +1,49 @@
+## pyqt5.yml
+
+- This module will build and install two python packages to `${FLATPAK_DEST}`:  
+
+```text
+PyQt5-sip
+PyQt5
+```
+
+- Support setting specific compile options  
+
+  Like `--enable|disable QtGui`  
+  Here are other [modules](https://doc.qt.io/qtforpython/modules.html) and other [options](https://www.riverbankcomputing.com/static/Docs/PyQt5/installation.html#building-and-installing-from-source)
+
+  `confirm-license` and `no-dbus-python` are hard-coded
+
+- This module will create `${FLATPAK_DEST}/build-pyqt5` and delete this folder during cleanup phase
+
+### example
+
+```yaml
+app-id: org.flathub.app
+runtime: org.kde.Platform
+runtime-version: '5.15-21.08'
+sdk: org.kde.Sdk
+#...
+
+# only global build-options can pass env to modules
+# so put the opts here
+build-options:
+  env:
+    PYQT5_OPTS: >-
+      --no-designer-plugin
+      --no-qml-plugin
+      --no-tools
+      --enable QtCore
+      --enable QtGui
+      --enable QtNetwork
+      --enable QtWidgets
+
+modules:
+  - shared-modules/pyqt5/pyqt5.yml
+  
+  - name: app
+    #...
+```
+
+
+

--- a/pyqt5/README.md
+++ b/pyqt5/README.md
@@ -47,3 +47,8 @@ modules:
 
 
 
+## pyqtwebengine.yml
+
+Depends on `pyqt5.yml` and [io.qt.qtwebengine.BaseApp](https://github.com/flathub/io.qt.qtwebengine.BaseApp)
+
+Add BaseApp and `shared-modules/pyqt5/pyqtwebengine.yml` to use, and need to add `pyqt5.yml` before this

--- a/pyqt5/private/flatpak-sip
+++ b/pyqt5/private/flatpak-sip
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo "opts: $@"
+export PATH=${BUILD_PYQT_PATH}/bin:${PATH}
+
+PY_VER=python$(python3 -c 'import sys; print(sys.version[:3])')
+export PYTHONPATH=${BUILD_PYQT_PATH}/lib/${PY_VER}/site-packages
+
+sip-install \
+  --target-dir ${FLATPAK_DEST}/lib/${PY_VER}/site-packages \
+  --scripts-dir ${FLATPAK_DEST}/bin \
+  --jobs ${FLATPAK_BUILDER_N_JOBS} \
+  --build-dir ./build \
+  --concatenate 1 \
+  --no-docstrings \
+  --debug \
+  --verbose $@

--- a/pyqt5/private/gen-dependencies.sh
+++ b/pyqt5/private/gen-dependencies.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+pip_generator="$PWD/flatpak-builder-tools/pip/flatpak-pip-generator"
+${pip_generator} --cleanup all 'PyQt-builder>=1.9,<2' --output pyqt-builder
+${pip_generator} PyQt5-sip --output pyqt5-sip
+
+sed -i -E 's:(FLATPAK_DEST.):\1/build-pyqt5:g' pyqt-builder.json

--- a/pyqt5/private/pyqt-builder.json
+++ b/pyqt5/private/pyqt-builder.json
@@ -1,0 +1,37 @@
+{
+    "name": "python3-PyQt-builder",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST}/build-pyqt5 \"PyQt-builder>=1.9,<2\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl",
+            "sha256": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/80/c1/23fd82ad3121656b585351aba6c19761926bb0db2ebed9e4ff09a43a3fcc/pyparsing-3.0.7-py3-none-any.whl",
+            "sha256": "a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl",
+            "sha256": "ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/de/c1/9ac5596c10f6ce28abc1849ed1b6299b3953af0b6ff21e227024991a517e/sip-6.5.1.tar.gz",
+            "sha256": "204f0240db8999a749d638a987b351861843e69239b811ec3d1881412c3706a6"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e4/55/db354bd9dfa613c8f8f6ecb81617caefdfb3e77befba098f8e14ed95e385/PyQt_builder-1.12.2-py3-none-any.whl",
+            "sha256": "48f754394d235307201ec2b5355934858741201af09433ff543ca40ae57b7865"
+        }
+    ],
+    "cleanup": [
+        "*"
+    ]
+}

--- a/pyqt5/private/pyqt5-sip.json
+++ b/pyqt5/private/pyqt5-sip.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-PyQt5-sip",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyQt5-sip\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/c0/86/6b60c6a1b1d10524ed50fc4c6a2989492512bd46292a711318a53b243774/PyQt5_sip-12.9.1.tar.gz",
+            "sha256": "2f24f299b44c511c23796aafbbb581bfdebf78d0905657b7cee2141b4982030e"
+        }
+    ]
+}

--- a/pyqt5/pyqt5.yml
+++ b/pyqt5/pyqt5.yml
@@ -1,0 +1,28 @@
+name: PyQt5
+build-options:
+  env:
+    BUILD_PYQT_PATH: /app/build-pyqt5
+  arch:
+    aarch64:
+      env:
+        ARCH_OPTS: '--disabled-feature PyQt_Desktop_OpenGL'
+buildsystem: simple
+build-commands:
+  - ./flatpak-sip ${ARCH_OPTS}
+    --confirm-license
+    --no-dbus-python 
+    ${PYQT5_OPTS}
+sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/3b/27/fd81188a35f37be9b3b4c2db1654d9439d1418823916fe702ac3658c9c41/PyQt5-5.15.6.tar.gz
+    sha256: 80343bcab95ffba619f2ed2467fd828ffeb0a251ad7225be5fc06dcc333af452
+    x-checker-data:
+      type: pypi
+      name: PyQt5
+
+  - type: file
+    path: private/flatpak-sip
+
+modules:
+  - private/pyqt-builder.json
+  - private/pyqt5-sip.json

--- a/pyqt5/pyqtwebengine.yml
+++ b/pyqt5/pyqtwebengine.yml
@@ -1,0 +1,18 @@
+name: PyQtWebEngine
+build-options:
+  env: 
+    QMAKEPATH: /app/lib
+    BUILD_PYQT_PATH: /app/build-pyqt5
+buildsystem: simple
+build-commands:
+  - ./flatpak-sip
+sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/60/66/56e118abb4cddd8e4bea6f89bdec834069b52479fb991748f1b21950811e/PyQtWebEngine-5.15.5.tar.gz
+    sha256: ab47608dccf2b5e4b950d5a3cc704b17711af035024d07a9b71ad29fc103b941
+    x-checker-data:
+      type: pypi
+      name: PyQtWebEngine
+
+  - type: file
+    path: private/flatpak-sip


### PR DESCRIPTION
## pyqt5.yml

- This module will build and install two python packages to `${FLATPAK_DEST}`:  

```text
PyQt5-sip
PyQt5
```

- Support setting specific compile options  

  Like `--enable|disable QtGui`  
  Here are other [modules](https://doc.qt.io/qtforpython/modules.html) and other [options](https://www.riverbankcomputing.com/static/Docs/PyQt5/installation.html#building-and-installing-from-source)

  `confirm-license` and `no-dbus-python` are hard-coded

- This module will create `${FLATPAK_DEST}/build-pyqt5` and delete this folder during cleanup phase

### example

```yaml
app-id: org.flathub.app
runtime: org.kde.Platform
runtime-version: '5.15-21.08'
sdk: org.kde.Sdk
#...
# only global build-options can pass env to modules
# so put the opts here
build-options:
  env:
    PYQT5_OPTS: >-
      --no-designer-plugin
      --no-qml-plugin
      --no-tools
      --enable QtCore
      --enable QtGui
      --enable QtNetwork
      --enable QtWidgets
modules:
  - shared-modules/pyqt5/pyqt5.yml
  
  - name: app
    #...
```
