### PR TITLE
Update X11-avoidance patch

### DIFF
--- a/libcanberra/0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
+++ b/libcanberra/0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
@@ -1,13 +1,14 @@
-From c0620e432650e81062c1967cc669829dbd29b310 Mon Sep 17 00:00:00 2001
+From d6dd5cdf45c1aac6c0519c8a4f5f89321770fb53 Mon Sep 17 00:00:00 2001
 From: Michael Meeks <michael.meeks@suse.com>
 Date: Fri, 9 Nov 2012 16:16:40 +0000
 Subject: [PATCH] gtk: Don't assume all GdkDisplays are GdkX11Displays:
  broadway/wayland
 
+Co-Authored-By: Bastien Nocera <hadess@hadess.net>
 ---
  src/canberra-gtk-module.c | 15 +++++++++++++++
- src/canberra-gtk.c        |  5 +++++
- 2 files changed, 20 insertions(+)
+ src/canberra-gtk.c        | 28 ++++++++++++++++++++++------
+ 2 files changed, 37 insertions(+), 6 deletions(-)
 
 diff --git a/src/canberra-gtk-module.c b/src/canberra-gtk-module.c
 index 67791f0..c1532ab 100644
@@ -50,7 +51,7 @@ index 67791f0..c1532ab 100644
           * ignore them */
  
 diff --git a/src/canberra-gtk.c b/src/canberra-gtk.c
-index 34446f5..08cb668 100644
+index 34446f5..47285f8 100644
 --- a/src/canberra-gtk.c
 +++ b/src/canberra-gtk.c
 @@ -185,6 +185,11 @@ static gint window_get_desktop(GdkDisplay *d, GdkWindow *w) {
@@ -65,6 +66,58 @@ index 34446f5..08cb668 100644
          if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), GDK_WINDOW_XID(w),
                                 gdk_x11_get_xatom_by_name_for_display(d, "_NET_WM_DESKTOP"),
                                 0, G_MAXLONG, False, XA_CARDINAL, &type_return,
+@@ -254,18 +259,28 @@ int ca_gtk_proplist_set_for_widget(ca_proplist *p, GtkWidget *widget) {
+ 
+         if (gtk_widget_get_realized(GTK_WIDGET(w))) {
+                 GdkWindow *dw = NULL;
++#ifdef GDK_IS_X11_DISPLAY
+                 GdkScreen *screen = NULL;
++#endif
+                 GdkDisplay *display = NULL;
+                 gint x = -1, y = -1, width = -1, height = -1, screen_width = -1, screen_height = -1;
+ 
+-                if ((dw = gtk_widget_get_window(GTK_WIDGET(w))))
+-                        if ((ret = ca_proplist_setf(p, CA_PROP_WINDOW_X11_XID, "%lu", (unsigned long) GDK_WINDOW_XID(dw))) < 0)
+-                                return ret;
++                if ((dw = gtk_widget_get_window(GTK_WIDGET(w)))) {
++#ifdef GDK_IS_X11_DISPLAY
++                        if (GDK_IS_X11_DISPLAY(display)) {
++                                if ((ret = ca_proplist_setf(p, CA_PROP_WINDOW_X11_XID, "%lu", (unsigned long) GDK_WINDOW_XID(dw))) < 0)
++                                        return ret;
++                        }
++#endif
++                }
+ 
+                 if ((display = gtk_widget_get_display(GTK_WIDGET(w)))) {
+-                        if ((t = gdk_display_get_name(display)))
++#ifdef GDK_IS_X11_DISPLAY
++                        if (GDK_IS_X11_DISPLAY(display) && (t = gdk_display_get_name(display))) {
+                                 if ((ret = ca_proplist_sets(p, CA_PROP_WINDOW_X11_DISPLAY, t)) < 0)
+                                         return ret;
++                        }
++#endif
+ 
+                         if (dw)  {
+                                 gint desktop = window_get_desktop(display, dw);
+@@ -276,7 +291,8 @@ int ca_gtk_proplist_set_for_widget(ca_proplist *p, GtkWidget *widget) {
+                         }
+                 }
+ 
+-                if ((screen = gtk_widget_get_screen(GTK_WIDGET(w)))) {
++#ifdef GDK_IS_X11_DISPLAY
++                if (GDK_IS_X11_DISPLAY(display) && (screen = gtk_widget_get_screen(GTK_WIDGET(w)))) {
+ 
+                         if ((ret = ca_proplist_setf(p, CA_PROP_WINDOW_X11_SCREEN, "%i", gdk_screen_get_number(screen))) < 0)
+                                 return ret;
+@@ -285,7 +301,7 @@ int ca_gtk_proplist_set_for_widget(ca_proplist *p, GtkWidget *widget) {
+                                 if ((ret = ca_proplist_setf(p, CA_PROP_WINDOW_X11_MONITOR, "%i", gdk_screen_get_monitor_at_window(screen, dw))) < 0)
+                                         return ret;
+                 }
+-
++#endif
+                 /* FIXME, this might cause a round trip */
+ 
+                 if (dw) {
 -- 
-2.29.2
+2.34.1
 


### PR DESCRIPTION
This happened running cheese-test-chooser on a GNOME Wayland system.
```
 #0  0x00007ffff76432ef in g_log_writer_default () at /lib64/libglib-2.0.so.0
 #1  0x00007ffff763c9f3 in g_log_structured_array () at /lib64/libglib-2.0.so.0
 #2  0x00007ffff763cbf3 in g_log_structured_standard () at /lib64/libglib-2.0.so.0
 #3  0x00007ffff73694b7 in gdk_x11_window_get_xid () at /lib64/libgdk-3.so.0
 #4  0x00007ffff6f92f43 in ca_gtk_proplist_set_for_widget (p=0xba7fc0, widget=widget@entry=0x592300) at /usr/src/debug/libcanberra-0.30-27.fc35.x86_64/src/canberra-gtk.c:268
 #5  0x00007ffff6f93a50 in ca_gtk_play_for_widget (w=0x592300, id=id@entry=0) at /usr/src/debug/libcanberra-0.30-27.fc35.x86_64/src/canberra-gtk.c:457
 #6  0x00007ffff7fb8e9d in take_button_clicked_cb (button=<optimized out>, widget=0x592300) at ../../../../Projects/jhbuild/cheese/libcheese/cheese-avatar-widget.c:125
 #7  0x00007ffff774faba in g_signal_emit_valist () at /lib64/libgobject-2.0.so.0
 #8  0x00007ffff774fc03 in g_signal_emit () at /lib64/libgobject-2.0.so.0
 #9  0x00007ffff785aaf0 in gtk_real_button_released () at /lib64/libgtk-3.so.0
 #10 0x00007ffff774faba in g_signal_emit_valist () at /lib64/libgobject-2.0.so.0
 #11 0x00007ffff774fc03 in g_signal_emit () at /lib64/libgobject-2.0.so.0
 #12 0x00007ffff785a887 in multipress_released_cb () at /lib64/libgtk-3.so.0
 #13 0x00007ffff7818105 in _gtk_marshal_VOID__INT_DOUBLE_DOUBLEv () at /lib64/libgtk-3.so.0
 #14 0x00007ffff774faba in g_signal_emit_valist () at /lib64/libgobject-2.0.so.0
 #15 0x00007ffff774fc03 in g_signal_emit () at /lib64/libgobject-2.0.so.0
 #16 0x00007ffff793b614 in gtk_gesture_multi_press_end () at /lib64/libgtk-3.so.0
 #17 0x00007ffff77362f6 in g_cclosure_marshal_VOID__BOXEDv () at /lib64/libgobject-2.0.so.0
 #18 0x00007ffff774faba in g_signal_emit_valist () at /lib64/libgobject-2.0.so.0
 #19 0x00007ffff774fc03 in g_signal_emit () at /lib64/libgobject-2.0.so.0
 #20 0x00007ffff792d88b in _gtk_gesture_check_recognized.lto_priv.0 () at /lib64/libgtk-3.so.0
 #21 0x00007ffff7936e13 in gtk_gesture_handle_event () at /lib64/libgtk-3.so.0
 #22 0x00007ffff793c2c0 in gtk_gesture_single_handle_event () at /lib64/libgtk-3.so.0
 #23 0x00007ffff78f4ba0 in gtk_event_controller_handle_event () at /lib64/libgtk-3.so.0
 #24 0x00007ffff7aecc95 in _gtk_widget_run_controllers.lto_priv.0 () at /lib64/libgtk-3.so.0
 #25 0x00007ffff78167d8 in _gtk_marshal_BOOLEAN__BOXEDv () at /lib64/libgtk-3.so.0
 #26 0x00007ffff774faba in g_signal_emit_valist () at /lib64/libgobject-2.0.so.0
 #27 0x00007ffff774fc03 in g_signal_emit () at /lib64/libgobject-2.0.so.0
 #28 0x00007ffff7afc644 in gtk_widget_event_internal.part.0.lto_priv () at /lib64/libgtk-3.so.0
 #29 0x00007ffff7987ee0 in propagate_event.lto_priv () at /lib64/libgtk-3.so.0
 #30 0x00007ffff7988cca in gtk_main_do_event () at /lib64/libgtk-3.so.0
 #31 0x00007ffff72ff543 in _gdk_event_emit () at /lib64/libgdk-3.so.0
 #32 0x00007ffff7331af6 in gdk_event_source_dispatch () at /lib64/libgdk-3.so.0
 #33 0x00007ffff763805f in g_main_context_dispatch () at /lib64/libglib-2.0.so.0
 #34 0x00007ffff768d298 in g_main_context_iterate.constprop () at /lib64/libglib-2.0.so.0
 #35 0x00007ffff7637773 in g_main_loop_run () at /lib64/libglib-2.0.so.0
 #36 0x00007ffff78dc2d2 in gtk_dialog_run () at /lib64/libgtk-3.so.0
 #37 0x00000000004011a3 in main (argc=<optimized out>, argv=<optimized out>) at ../../../../Projects/jhbuild/cheese/tests/cheese-test-chooser.c:43
```