### PR TITLE
libsecret: Update to 0.20.5

### DIFF
--- a/libsecret/libsecret.json
+++ b/libsecret/libsecret.json
@@ -15,10 +15,9 @@
   ],
   "sources": [
     {
-      "type": "git",
-      "url": "https://gitlab.gnome.org/GNOME/libsecret.git",
-      "tag": "0.20.4",
-      "commit": "3fe635e64efd4b8dbc9ec3548b0bc8034c7665c4"
+      "type": "archive",
+      "url": "https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz",
+      "sha256sum": "3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d"
     }
   ]
 }


### PR DESCRIPTION
Also use download.gnome.org instead of git repo.