### PR TITLE
Add clutter module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 *                  @flathub/reviewers
 
 /dbus-glib/        @TingPing
+/clutter/          @A6GibKm
 /gtk2/             @TingPing
 /gudev/            @Erick555
 /intltool/         @TingPing

--- a/clutter/clutter.json
+++ b/clutter/clutter.json
@@ -1,0 +1,51 @@
+{
+    "name": "clutter-gtk",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.gnome.org/sources/clutter-gtk/1.8/clutter-gtk-1.8.4.tar.xz",
+            "sha256": "521493ec038973c77edcb8bc5eac23eed41645117894aaee7300b2487cb42b06"
+        }
+    ],
+    "modules": [
+        {
+            "name": "cogl",
+            "config-opts": [
+                "--disable-cogl-gst",
+                "--enable-xlib-egl-platform",
+                "--enable-wayland-egl-platform"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/cogl/1.22/cogl-1.22.8.tar.xz",
+                    "sha256": "a805b2b019184710ff53d0496f9f0ce6dcca420c141a0f4f6fcc02131581d759"
+                }
+            ]
+        },
+        {
+            "name": "clutter",
+            "config-opts": [
+                "--enable-egl-backend",
+                "--enable-wayland-backend"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/clutter/1.26/clutter-1.26.4.tar.xz",
+                    "sha256": "8b48fac159843f556d0a6be3dbfc6b083fc6d9c58a20a49a6b4919ab4263c4e6"
+                }
+            ]
+        },
+        {
+            "name": "clutter-gst",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/clutter-gst/3.0/clutter-gst-3.0.27.tar.xz",
+                    "sha256": "fe69bd6c659d24ab30da3f091eb91cd1970026d431179b0724f13791e8ad9f9d"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
GNOME 42 removed clutter and clutter-gtk from the SDK.

Fixes: https://github.com/flathub/shared-modules/issues/178