### PR TITLE
fix(libusb): switch to .tar.bz2 tarball

### DIFF
--- a/libusb/libusb.json
+++ b/libusb/libusb.json
@@ -9,8 +9,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/libusb/libusb/archive/v1.0.26.tar.gz",
-            "sha256": "a09bff99c74e03e582aa30759cada218ea8fa03580517e52d463c59c0b25e240"
+            "url": "https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2",
+            "sha256": "12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5"
         }
     ],
     "post-install": [


### PR DESCRIPTION
According to a txt shipped with the [release](https://github.com/libusb/libusb/releases/tag/v1.0.26) on their github, we should use the .tar.bz2 file instead of the .tar.gz.