### PR TITLE
Add dependency on glu/glu-9.json to SDL/sdl12-compat.json

### DIFF
--- a/SDL/sdl12-compat.json
+++ b/SDL/sdl12-compat.json
@@ -10,5 +10,8 @@
             "url": "https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-1.2.52.tar.gz",
             "sha256": "5bd7942703575554670a8767ae030f7921a0ac3c5e2fd173a537b7c7a8599014"
         }
+    ],
+    "modules": [
+        "../glu/glu-9.json"
     ]
 }


### PR DESCRIPTION
SDL/sdl12-compat.json will fail to build unless glu/glu-9.json is available, so make that dependency explicit.  (This fixes issue #202)

I've tested this by removing the line to build `shared-modules/glu/glu-9.json` as a direct dependency of net.sourceforge.tomatoes.IHaveNoTomatoes in my local working copy and sdl12-compat continues to build successfully.

Conversely, earlier today, I had to *add* `shared-modules/glu/glu-9.json` as a direct dependency to get `shared-modules/SDL/sdl12-compat.json` to build in another manifest I'm working on.