### PR TITLE
Update to fluidsynth 2.2.9

### DIFF
--- a/linux-audio/fluidsynth2-static.json
+++ b/linux-audio/fluidsynth2-static.json
@@ -20,8 +20,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.8.tar.gz",
-      "sha256": "7c29a5cb7a2755c8012d941d1335da7bda957bbb0a86b7c59215d26773bb51fe"
+      "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.9.tar.gz",
+      "sha256": "bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159"
     }
   ]
 }

--- a/linux-audio/fluidsynth2.json
+++ b/linux-audio/fluidsynth2.json
@@ -14,8 +14,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.8.tar.gz",
-            "sha256": "7c29a5cb7a2755c8012d941d1335da7bda957bbb0a86b7c59215d26773bb51fe"
+            "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.9.tar.gz",
+            "sha256": "bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159"
         }
     ]
 }


### PR DESCRIPTION
FluidSynth 2.2.9 has been released only a few days ago.

I've realized that I would like to add a configuration option like this one:

~~~
    "-DDEFAULT_SOUNDFONT=$HOME/.local/share/soundfonts/default.sf2"
~~~

To override the default hardcoded value in fluidsynth, which is: `/usr/share/soundfonts/default.sf2`.

But obviously resolving `$HOME` at runtime, not at configuration time. I know the environment variables `$XDG_DATA_DIRS`  and `$XDG_DATA_HOME`, but I have the same problem as with `$HOME`. 

It would be nice to be able to also provide soundfont flatpaks, leveraging a shared default location.
