### PR TITLE
update FluidSynth to v2.3.0

### DIFF
--- a/linux-audio/fluidsynth2-static.json
+++ b/linux-audio/fluidsynth2-static.json
@@ -6,12 +6,12 @@
     "cxxflags": "-fPIC"
   },
   "config-opts": [
-    "-DLIB_SUFFIX=",
     "-DBUILD_SHARED_LIBS=OFF"
   ],
   "cleanup": [
     "/bin",
     "/include",
+    "/lib/cmake",
     "/lib/pkgconfig",
     "/share/man",
     "*.so",
@@ -20,8 +20,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.9.tar.gz",
-      "sha256": "bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159"
+      "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.3.0.tar.gz",
+      "sha256": "1df5a1afb91acf3b945b7fdb89ac0d99877622161d9b5155533da59113eaaa20"
     }
   ]
 }

--- a/linux-audio/fluidsynth2.json
+++ b/linux-audio/fluidsynth2.json
@@ -1,12 +1,10 @@
 {
     "name": "fluidsynth",
     "buildsystem": "cmake-ninja",
-    "config-opts": [
-        "-DLIB_SUFFIX="
-    ],
     "cleanup": [
         "/bin",
         "/include",
+        "/lib/cmake",
         "/lib/pkgconfig",
         "/share/man",
         "*.so"
@@ -14,8 +12,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.2.9.tar.gz",
-            "sha256": "bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159"
+            "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.3.0.tar.gz",
+            "sha256": "1df5a1afb91acf3b945b7fdb89ac0d99877622161d9b5155533da59113eaaa20"
         }
     ]
 }


### PR DESCRIPTION
This FluidSynth release is ABI compatible with v2.2.x but the build system has changed:
* LIB_SUFFIX option removed. Now using cmake module GNUInstallDirs.
* CMake exported targets, now supporting find_package(FluidSynth).