### PR TITLE
lua: Actually clean up manpages

### DIFF
--- a/lua5.3/lua-5.3.5.json
+++ b/lua5.3/lua-5.3.5.json
@@ -41,6 +41,6 @@
         "/bin",
         "/include",
         "/lib/pkgconfig",
-        "/share/man"
+        "/man"
     ]
 }

--- a/lua5.4/lua-5.4.json
+++ b/lua5.4/lua-5.4.json
@@ -39,6 +39,6 @@
         "/bin",
         "/include",
         "/lib/pkgconfig",
-        "/share/man"
+        "/man"
     ]
 }


### PR DESCRIPTION
For reasons unknown, Lua does not install its manpages to $PREFIX/share/man, but to $PREFIX/man.

The lua5.1 module already listed "/man" rather than "/share/man" in its cleanups.