### PR TITLE
Add libdecor 0.1.1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /intltool/         @TingPing
 /libappindicator/  @TingPing
 /libcanberra/      @hadess
+/libdecor/         @orowith2os
 /libsecret/        @Lctrs
 /libusb/           @A6GibKm
 /openjpeg/         @mbridon

--- a/libdecor/libdecor-0.1.1.json
+++ b/libdecor/libdecor-0.1.1.json
@@ -6,9 +6,9 @@
   ],
   "sources": [
     {
-      "type": "git",
-      "url": "https://gitlab.freedesktop.org/libdecor/libdecor.git",
-      "tag": "0.1.1"
+      "type": "archive",
+      "url": "https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.1.1/libdecor-0.1.1.tar.gz",
+      "sha256": "82adece5baeb6194292b0d1a91b4b3d10da41115f352a5e6c5844b20b88a0512"
     }
   ]
 }

--- a/libdecor/libdecor-0.1.1.json
+++ b/libdecor/libdecor-0.1.1.json
@@ -10,5 +10,8 @@
       "url": "https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.1.1/libdecor-0.1.1.tar.gz",
       "sha256": "82adece5baeb6194292b0d1a91b4b3d10da41115f352a5e6c5844b20b88a0512"
     }
-  ]
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig"
 }

--- a/libdecor/libdecor-0.1.1.json
+++ b/libdecor/libdecor-0.1.1.json
@@ -14,4 +14,5 @@
   "cleanup": [
     "/include",
     "/lib/pkgconfig"
+  ]
 }

--- a/libdecor/libdecor-0.1.1.json
+++ b/libdecor/libdecor-0.1.1.json
@@ -1,0 +1,14 @@
+{
+  "name": "libdecor",
+  "buildsystem": "meson",
+  "config-opts": [
+    "-Ddemo=false"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://gitlab.freedesktop.org/libdecor/libdecor.git",
+      "tag": "0.1.1"
+    }
+  ]
+}


### PR DESCRIPTION
For libdecor 0.2.0 (or the next release, whatever), it'll need to have GTK as a build dep for the GTK plugin. This could be done in another module, and then pulled in by libdecor. I'll handle it when the time comes.

This is intended to be used alongside an SDL2 shared module, but could be useful for https://github.com/flathub/org.blender.Blender/pull/126