### PR TITLE
Add READMEs to SDL1 and libdecor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This repository contains commonly shared modules and is intended to be used as a git submodule.
 
+Each submodule may include additional instructions to be used properly. Please check the folder containing that module to see if anything extra needs to be done.
+
 To use shared modules for packaging an application, add the submodule:
 
 ```

--- a/SDL/README.md
+++ b/SDL/README.md
@@ -1,0 +1,3 @@
+This submodule contains the manifests and several patches for SDL1 and its compatibility layer.
+
+If using the compatibility layer, please add the SDL2 submodule as a dependency as well to benefit from the latest bug fixes.

--- a/libdecor/README.md
+++ b/libdecor/README.md
@@ -2,5 +2,5 @@ This is a shared module for libdecoration, used by several applications and util
 
 This will contain the latest versioned release of libdecor; if newer (devel) versions are desired, please manually add it to your flatpak manifest.
 
-The freedesktop runtime already bundles GTK3, so you don't need to do any more work to get native-looking CSDs on GNOME, at the very least.
+The freedesktop runtime already bundles GTK3, so you don't need to do any more work to get native-looking CSDs on GNOME with libdecor versions newer than 0.1.1.
 If it can't load the GTK3 plugin, it will fallback to Cairo.

--- a/libdecor/README.md
+++ b/libdecor/README.md
@@ -1,0 +1,6 @@
+This is a shared module for libdecoration, used by several applications and utilities to get window decorations on Wayland compositors that might not implement server-side decorations.
+
+This will contain the latest versioned release of libdecor; if newer (devel) versions are desired, please manually add it to your flatpak manifest.
+
+The freedesktop runtime already bundles GTK3, so you don't need to do any more work to get native-looking CSDs on GNOME, at the very least.
+If it can't load the GTK3 plugin, it will fallback to Cairo.


### PR DESCRIPTION
IMO, other shared modules should follow this practice to be more verbose on how they're intended to be used. This is particularly useful in the case of something like libdecor, where using a specific runtime might be a concern (it was for me when I was trying to get GTK CSDs to work).