### PR TITLE
libcanberra: Clean up random files

### DIFF
--- a/libcanberra/libcanberra.json
+++ b/libcanberra/libcanberra.json
@@ -5,9 +5,15 @@
         "/bin",
         "/etc",
         "/include",
+        "/lib/gnome-settings-daemon-3.0",
+        "/lib/pkgconfig",
         "/libexec",
+        "/share/doc",
+        "/share/gdm",
+        "/share/gnome",
         "/share/gtk-doc",
-        "/share/man"
+        "/share/man",
+        "/share/vala"
     ],
     "config-opts": [
         "--disable-static",

--- a/libcanberra/libcanberra.json
+++ b/libcanberra/libcanberra.json
@@ -6,6 +6,7 @@
         "/etc",
         "/include",
         "/lib/gnome-settings-daemon-3.0",
+        "/lib/gtk-3.0",
         "/lib/pkgconfig",
         "/libexec",
         "/share/doc",


### PR DESCRIPTION
This module leaves so much stuff lying around that is not needed at
runtime. Clean it all up so that apps don't have to.
