### PR TITLE
Use ${FLATPAK_DEST} instead of hardcoding /app

### DIFF
--- a/libusb/libusb.json
+++ b/libusb/libusb.json
@@ -14,6 +14,6 @@
         }
     ],
     "post-install": [
-        "install -Dm644 COPYING /app/share/licenses/libusb/COPYING"
+        "install -Dm644 COPYING ${FLATPAK_DEST}/share/licenses/libusb/COPYING"
     ]
 }


### PR DESCRIPTION
The path is different when building extensions, so it fails when it copies the license.