### PR TITLE
Add LuaJIT 2.1.0-beta3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,3 +21,4 @@
 /pygtk/            @Eonfge
 /gzdoom/           @Eonfge
 /vorbisgain/       @Eonfge
+/luajit/           @ranisalt

--- a/luajit/luajit.json
+++ b/luajit/luajit.json
@@ -2,6 +2,7 @@
     "name": "luajit",
     "no-autogen": true,
     "make-args": [
+        "BUILDMODE=dynamic",
         "PREFIX=${FLATPAK_DEST}"
     ],
     "make-install-args": [
@@ -23,7 +24,6 @@
     "cleanup": [
         "/bin",
         "/include",
-        "/lib/*.a",
         "/lib/pkgconfig",
         "/share/man"
     ]

--- a/luajit/luajit.json
+++ b/luajit/luajit.json
@@ -1,0 +1,30 @@
+{
+    "name": "luajit",
+    "no-autogen": true,
+    "make-args": [
+        "PREFIX=${FLATPAK_DEST}"
+    ],
+    "make-install-args": [
+        "PREFIX=${FLATPAK_DEST}"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
+            "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3",
+            "x-checker-data": {
+                "type": "anitya",
+                "project-id": 6444,
+                "stable-only": false,
+                "url-template": "https://luajit.org/download/LuaJIT-$version.tar.gz"
+            }
+        }
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/*.a",
+        "/lib/pkgconfig",
+        "/share/man"
+    ]
+}


### PR DESCRIPTION
LuaJIT is [used by a lot of packages](https://github.com/search?q=org%3Aflathub%20luajit&type=code), notably Neovim, OBS Studio and a lot of media players (Celluloid, Haruna, MPV, and more).

Includes Anitya checker data. After cleanup, only shared libraries and extensions are left. This is what almost all, if not all, packages are using.