### PR TITLE
Anitya data checker for SDL2

### DIFF
--- a/SDL2/SDL2-no-libdecor.json
+++ b/SDL2/SDL2-no-libdecor.json
@@ -6,7 +6,13 @@
     {
       "type": "archive",
       "url": "https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.26.3.tar.gz",
-      "sha256": "c661205a553b7d252425f4b751ff13209e5e020b876bbfa1598494af61790057"
+      "sha256": "c661205a553b7d252425f4b751ff13209e5e020b876bbfa1598494af61790057",
+      "x-checker-data": {
+          "type": "anitya",
+          "project-id": 4779,
+          "versions": {"<": "3"},
+          "url-template": "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$version.tar.gz"
+        }
     }
   ],
   "cleanup": [ "/bin/sdl2-config", 

--- a/SDL2/SDL2-with-libdecor.json
+++ b/SDL2/SDL2-with-libdecor.json
@@ -7,7 +7,13 @@
     {
       "type": "archive",
       "url": "https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.26.3.tar.gz",
-      "sha256": "c661205a553b7d252425f4b751ff13209e5e020b876bbfa1598494af61790057"
+      "sha256": "c661205a553b7d252425f4b751ff13209e5e020b876bbfa1598494af61790057",
+      "x-checker-data": {
+          "type": "anitya",
+          "project-id": 4779,
+          "versions": {"<": "3"},
+          "url-template": "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$version.tar.gz"
+        }
     }
   ],
   "cleanup": [ "/bin/sdl2-config", 


### PR DESCRIPTION
This only adds a checker for sdl2-no-libdecor, ideally the with-libdecor manifest would reference no-libdecor so that there isn't any duplicated version checking. I'm unable to test it on my end currently, so someone else testing it would be appreciated.

If with-libdecor *can't* reference no-libdecor, I'll add the anitya checker to it.