### PR TITLE
update glu archive URL

### DIFF
--- a/glu/glu-9.json
+++ b/glu/glu-9.json
@@ -4,7 +4,7 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz",
+      "url": "https://archive.mesa3d.org/glu/glu-9.0.2.tar.xz",
       "sha256": "6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4"
     }
   ],


### PR DESCRIPTION
The old URL gives me:
```
Downloading sources
Downloading https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   162  100   162    0     0    268      0 --:--:-- --:--:-- --:--:--   268
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
Failed to download sources: module glu: server certificate verification failed. CAfile: none CRLfile: none
```
when using `flatpak-builder` locally, and:
```
$ curl https://mesa.freedesktop.org/archive/glu/glu-9.0.3.tar.xz 
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```