### PR TITLE
Update SDL2 to 2.26.4

### DIFF
--- a/SDL2/SDL2-no-libdecor.json
+++ b/SDL2/SDL2-no-libdecor.json
@@ -5,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.26.3.tar.gz",
-      "sha256": "c661205a553b7d252425f4b751ff13209e5e020b876bbfa1598494af61790057"
+      "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.26.4/SDL2-2.26.4.tar.gz",
+      "sha256": "1a0f686498fb768ad9f3f80b39037a7d006eac093aad39cb4ebcc832a8887231"
     }
   ],
   "cleanup": [ "/bin/sdl2-config", 

--- a/SDL2/SDL2-with-libdecor.json
+++ b/SDL2/SDL2-with-libdecor.json
@@ -1,4 +1,3 @@
-
 {
   "name": "SDL2",
   "buildsystem": "autotools",
@@ -6,8 +5,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/libsdl-org/SDL/archive/refs/tags/release-2.26.3.tar.gz",
-      "sha256": "c661205a553b7d252425f4b751ff13209e5e020b876bbfa1598494af61790057"
+      "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.26.4/SDL2-2.26.4.tar.gz",
+      "sha256": "1a0f686498fb768ad9f3f80b39037a7d006eac093aad39cb4ebcc832a8887231"
     }
   ],
   "cleanup": [ "/bin/sdl2-config", 


### PR DESCRIPTION
Use upstream generated release tarballs instead of GitHub's.

See #238 for details.