### PR TITLE
Added libsoup-2.4 (deprecated)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@
 /physfs/           @Mailaender
 /python2.7/        @bilelmoussaoui
 /linux-audio/      @hfiguiere
+/libsoup/          @hfiguiere
 /lua5.1/           @Unrud
 /mac/              @enzo1982 @Eonfge
 /pygtk/            @Eonfge

--- a/libsoup/libsoup-2.4.json
+++ b/libsoup/libsoup-2.4.json
@@ -1,0 +1,14 @@
+{
+    "name": "libsoup-2.4",
+    "buildsystem": "meson",
+    "config-opts": [
+        "-Dtests=false"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.3.tar.xz",
+            "sha256": "e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13"
+        }
+    ]
+}


### PR DESCRIPTION
marking as draft but there are a few apps that still haven't been ported. 