### PR TITLE
Add icoutils 0.32.3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,3 +23,4 @@
 /gzdoom/           @Eonfge
 /vorbisgain/       @Eonfge
 /luajit/           @ranisalt
+/icoutils/         @ranisalt

--- a/icoutils/icoutils.json
+++ b/icoutils/icoutils.json
@@ -1,0 +1,15 @@
+{
+  "name": "icoutils",
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://savannah.nongnu.org/download/icoutils/icoutils-0.32.3.tar.bz2",
+      "sha256": "17abe02d043a253b68b47e3af69c9fc755b895db68fdc8811786125df564c6e0",
+      "x-checker-data": {
+        "type": "anitya",
+        "project-id": 1360,
+        "url-template": "https://savannah.nongnu.org/download/icoutils/icoutils-$version.tar.bz2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
#### Summary

`icoutils` is a set of command-line tools used for working with Windows icon and cursor files. It can create, extract, and convert icons and cursors in different formats, and is useful for developers working with these resources in their applications.

It is currently used by 5 flathub packages. `icoutils` could be used in others to extract icons from Windows executables instead of providing their own icons.


