### PR TITLE
Update sdl12-compat to 1.2.64

### DIFF
--- a/SDL/sdl12-compat.json
+++ b/SDL/sdl12-compat.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-1.2.52.tar.gz",
-            "sha256": "5bd7942703575554670a8767ae030f7921a0ac3c5e2fd173a537b7c7a8599014"
+            "url": "https://github.com/libsdl-org/sdl12-compat/archive/refs/tags/release-1.2.64.tar.gz",
+            "sha256": "3e308e817c7f0c6383225485e9a67bf1119ad684b8cc519038671cc1b5d29861"
         }
     ],
     "modules": [


### PR DESCRIPTION
.This should a lot of improvements since the previous version of the module was apparently the initial release.

Tested with the Chibitracker flatpak (which I maintain) and apparently it works well.