### PR TITLE
Update libsecret 0.2 → 0.9

### DIFF
--- a/libsecret/libsecret.json
+++ b/libsecret/libsecret.json
@@ -16,8 +16,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz",
-      "sha256": "3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d"
+      "url": "https://download.gnome.org/sources/libsecret/0.9/libsecret-0.9.tar.xz",
+      "sha256": "8b1abfed2f5c88ff9a1801d5b6643331cc833dfe8d8b1dca982ae23bbd6de535"
     }
   ]
 }


### PR DESCRIPTION
Update 0.2 to 0.9, backwards compatible and fixes an error in flutter apps