### PR TITLE
Fix pygame and fluidsynth build

### DIFF
--- a/pygame/cython-fixes.patch
+++ b/pygame/cython-fixes.patch
@@ -1,0 +1,34 @@
+From ff04ba4bfbe65929534f61a9f66a39d03c973b78 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Sat, 9 Sep 2023 15:15:00 +0530
+Subject: [PATCH 1/2] Cython fixes
+
+---
+ src_c/pypm.pyx | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src_c/pypm.pyx b/src_c/pypm.pyx
+index d66e7a10..706726c6 100644
+--- a/src_c/pypm.pyx
++++ b/src_c/pypm.pyx
+@@ -5,6 +5,8 @@
+ # harrison@media.mit.edu
+ # written in Pyrex
+ 
++# cython: language_level=2
++
+ __version__ = "0.0.6"
+ 
+ import array
+@@ -277,7 +279,7 @@ cdef class Output:
+             PmPtr = <PmTimeProcPtr>&Pt_Time
+ 
+         if self.debug:
+-            print "Opening Midi Output"
++            print "Opening Midi Output", output_device
+ 
+         # Why is buffer size 0 here?
+         err = Pm_OpenOutput(&(self.midi), output_device, NULL, 0, PmPtr, NULL,
+-- 
+2.41.0
+

--- a/pygame/glib.patch
+++ b/pygame/glib.patch
@@ -1,0 +1,25 @@
+From 24d1e9c28518cb4b01344eaf8377f2d6d489ad50 Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Sat, 9 Sep 2023 12:04:16 +0530
+Subject: [PATCH] Fix deprecated GStaticMutex init with glib-2.70
+
+---
+ src/drivers/fluid_jack.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/drivers/fluid_jack.c b/src/drivers/fluid_jack.c
+index fe3cd752..613a9820 100644
+--- a/src/drivers/fluid_jack.c
++++ b/src/drivers/fluid_jack.c
+@@ -100,7 +100,7 @@ int fluid_jack_driver_process(jack_nframes_t nframes, void *arg);
+ int delete_fluid_jack_midi_driver(fluid_midi_driver_t *p);
+ 
+ 
+-static fluid_mutex_t last_client_mutex = G_STATIC_MUTEX_INIT;     /* Probably not necessary, but just in case drivers are created by multiple threads */
++static fluid_mutex_t last_client_mutex;     /* Probably not necessary, but just in case drivers are created by multiple threads */
+ static fluid_jack_client_t *last_client = NULL;       /* Last unpaired client. For audio/MIDI driver pairing. */
+ 
+ 
+-- 
+2.41.0
+

--- a/pygame/pygame-1.9.6.json
+++ b/pygame/pygame-1.9.6.json
@@ -5,11 +5,15 @@
             "type": "archive",
             "url": "https://files.pythonhosted.org/packages/0f/9c/78626be04e193c0624842090fe5555b3805c050dfaa81c8094d6441db2be/pygame-1.9.6.tar.gz",
             "sha256": "301c6428c0880ecd4a9e3951b80e539c33863b6ff356a443db1758de4f297957"
+        },
+        {
+            "type": "patch",
+            "path": "cython-fixes.patch"
         }
     ],
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --ignore-installed --no-deps --prefix=/app ."
+        "python setup.py cython install --prefix=/app --root=/"
     ],
     "build-options": {
         "env": {
@@ -84,6 +88,10 @@
                 {
                     "type": "patch",
                     "path": "fluidsynth-no-rawmidi.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "glib.patch"
                 }
             ]
         },


### PR DESCRIPTION
Recythonize sources before building, see https://www.pygame.org/wiki/GettingStarted#Compilation

> Some of the .c files are generated by [Cython](https://cython.org/) from .pyx files. Running "setup.py cython" will update them.

C-API introduced a bunch of breaking changes including a header relocation.

Fixes https://github.com/flathub/shared-modules/issues/201

Cython patch is from pygame upstream but adapted on top of 1.9.6 instead of 2.x.y