### PR TITLE
Update SDL2 version.

### DIFF
--- a/SDL2/SDL2-no-libdecor.json
+++ b/SDL2/SDL2-no-libdecor.json
@@ -5,18 +5,18 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.26.4/SDL2-2.26.4.tar.gz",
-      "sha256": "1a0f686498fb768ad9f3f80b39037a7d006eac093aad39cb4ebcc832a8887231"
+      "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.28.3/SDL2-2.28.3.tar.gz",
+      "sha256": "7acb8679652701a2504d734e2ba7543ec1a83e310498ddd22fd44bf965eb5518"
     }
   ],
-  "cleanup": [ "/bin/sdl2-config", 
-               "/include", 
-               "/lib/libSDL2.la", 
-               "/lib/libSDL2main.a", 
-               "/lib/libSDL2main.la", 
-               "/lib/libSDL2_test.a", 
-               "/lib/libSDL2_test.la", 
-               "/lib/cmake", 
+  "cleanup": [ "/bin/sdl2-config",
+               "/include",
+               "/lib/libSDL2.la",
+               "/lib/libSDL2main.a",
+               "/lib/libSDL2main.la",
+               "/lib/libSDL2_test.a",
+               "/lib/libSDL2_test.la",
+               "/lib/cmake",
                "/share/aclocal",
                "/lib/pkgconfig"]
 }

--- a/SDL2/SDL2-with-libdecor.json
+++ b/SDL2/SDL2-with-libdecor.json
@@ -5,18 +5,18 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.26.4/SDL2-2.26.4.tar.gz",
-      "sha256": "1a0f686498fb768ad9f3f80b39037a7d006eac093aad39cb4ebcc832a8887231"
+      "url": "https://github.com/libsdl-org/SDL/releases/download/release-2.28.3/SDL2-2.28.3.tar.gz",
+      "sha256": "7acb8679652701a2504d734e2ba7543ec1a83e310498ddd22fd44bf965eb5518"
     }
   ],
-  "cleanup": [ "/bin/sdl2-config", 
-               "/include", 
-               "/lib/libSDL2.la", 
-               "/lib/libSDL2main.a", 
-               "/lib/libSDL2main.la", 
-               "/lib/libSDL2_test.a", 
-               "/lib/libSDL2_test.la", 
-               "/lib/cmake", 
+  "cleanup": [ "/bin/sdl2-config",
+               "/include",
+               "/lib/libSDL2.la",
+               "/lib/libSDL2main.a",
+               "/lib/libSDL2main.la",
+               "/lib/libSDL2_test.a",
+               "/lib/libSDL2_test.la",
+               "/lib/cmake",
                "/share/aclocal",
                "/lib/pkgconfig"],
   "modules": [ "../libdecor/libdecor-0.1.1.json" ]


### PR DESCRIPTION
I need to update the SDL2 version provided by flathub given that the current version has some bugs in Wayland sessions that could potentially break many applications.
[Here's](https://github.com/SpartanJ/ecode/issues/102) the current issue that I cannot avoid with the current version and I verified that it's fixed in the latest version.