### PR TITLE
Update libdecor to 0.2.0

### DIFF
--- a/SDL2/SDL2-with-libdecor.json
+++ b/SDL2/SDL2-with-libdecor.json
@@ -19,5 +19,5 @@
                "/lib/cmake",
                "/share/aclocal",
                "/lib/pkgconfig"],
-  "modules": [ "../libdecor/libdecor-0.1.1.json" ]
+  "modules": [ "../libdecor/libdecor-0.2.0.json" ]
 }

--- a/libdecor/libdecor-0.2.0.json
+++ b/libdecor/libdecor-0.2.0.json
@@ -7,8 +7,8 @@
   "sources": [
     {
       "type": "archive",
-      "url": "https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.1.1/libdecor-0.1.1.tar.gz",
-      "sha256": "82adece5baeb6194292b0d1a91b4b3d10da41115f352a5e6c5844b20b88a0512"
+      "url": "https://gitlab.freedesktop.org/libdecor/libdecor/-/archive/0.2.0/libdecor-0.2.0.tar.gz",
+      "sha256": "455acc1e1af43657fadbc79a9bac41e2d465ad1abdf1a6f8405e461350046f22"
     }
   ],
   "cleanup": [


### PR DESCRIPTION
Is replacing the 0.1.1 file is correct, rather than just adding 0.2.0 alongside?