### PR TITLE
libusb: pass `--disable-udev`, fix hotplug

### DIFF
--- a/libusb/libusb.json
+++ b/libusb/libusb.json
@@ -11,6 +11,10 @@
             "type": "archive",
             "url": "https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2",
             "sha256": "12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5"
+        },
+        {
+          "type": "patch",
+          "path": "libusb_fix_hotpug.patch"
         }
     ],
     "post-install": [

--- a/libusb/libusb.json
+++ b/libusb/libusb.json
@@ -1,6 +1,6 @@
 {
     "name": "libusb",
-    "config-opts": [ "--disable-static" ],
+    "config-opts": [ "--disable-static", "--disable-udev" ],
     "cleanup": [
         "/lib/*.la",
         "/lib/pkgconfig",

--- a/libusb/libusb_fix_hotpug.patch
+++ b/libusb/libusb_fix_hotpug.patch
@@ -1,0 +1,24 @@
+diff -ruN libusb-vanilla/libusb/os/linux_netlink.c libusb-modified/libusb/os/linux_netlink.c
+--- libusb-vanilla/libusb/os/linux_netlink.c	2021-10-31 11:33:12.000000000 +0300
++++ libusb-modified/libusb/os/linux_netlink.c	2023-10-23 20:09:23.309671739 +0300
+@@ -288,7 +288,6 @@
+ 	int detached, r;
+ 	ssize_t len;
+ 	struct cmsghdr *cmsg;
+-	struct ucred *cred;
+ 	struct sockaddr_nl sa_nl;
+ 	struct iovec iov = { .iov_base = msg_buffer, .iov_len = sizeof(msg_buffer) };
+ 	struct msghdr msg = {
+@@ -322,12 +321,6 @@
+ 		return -1;
+ 	}
+
+-	cred = (struct ucred *)CMSG_DATA(cmsg);
+-	if (cred->uid != 0) {
+-		usbi_dbg(NULL, "ignoring netlink message with non-zero sender UID %u", (unsigned int)cred->uid);
+-		return -1;
+-	}
+-
+ 	r = linux_netlink_parse(msg_buffer, (size_t)len, &detached, &sys_name, &busnum, &devaddr);
+ 	if (r)
+ 		return r;


### PR DESCRIPTION
I'm using libusb (via libgusb) in my program and this is required to get device detection to work. Niepce also [uses it](https://gitlab.gnome.org/GNOME/niepce/-/blob/master/flatpak/net.figuiere.Niepce.json?ref_type=heads#L42) in their flatpak version.