### PR TITLE
Use openresty/luajit2 to get significantly newer version of luajit.

### DIFF
--- a/luajit/luajit.json
+++ b/luajit/luajit.json
@@ -10,15 +10,10 @@
     ],
     "sources": [
         {
-            "type": "archive",
-            "url": "https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
-            "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3",
-            "x-checker-data": {
-                "type": "anitya",
-                "project-id": 6444,
-                "stable-only": false,
-                "url-template": "https://luajit.org/download/LuaJIT-$version.tar.gz"
-            }
+            "type": "git",
+            "url": "https://luajit.org/git/luajit.git",
+            "tag": "v2.1.ROLLING",
+            "commit": "2090842410e0ba6f81fad310a77bf5432488249a"
         }
     ],
     "cleanup": [

--- a/luajit/luajit.json
+++ b/luajit/luajit.json
@@ -13,7 +13,7 @@
             "type": "git",
             "url": "https://github.com/openresty/luajit2.git",
             "tag": "v2.1-20231117",
-            "commit": "4182d6bf37e9f8d1cb5d6e83b1db66de84b95101"
+            "commit": "4182d6bf37e9f8d1cb5d6e83b1db66de84b95101",
             "x-checker-data": {
                 "type": "git",
                 "tag-pattern": "^v([\d.-]+)$",

--- a/luajit/luajit.json
+++ b/luajit/luajit.json
@@ -11,9 +11,14 @@
     "sources": [
         {
             "type": "git",
-            "url": "https://luajit.org/git/luajit.git",
-            "tag": "v2.1.ROLLING",
-            "commit": "2090842410e0ba6f81fad310a77bf5432488249a"
+            "url": "https://github.com/openresty/luajit2.git",
+            "tag": "v2.1-20231117",
+            "commit": "4182d6bf37e9f8d1cb5d6e83b1db66de84b95101"
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^v([\d.-]+)$",
+                "stable-only": false
+            }
         }
     ],
     "cleanup": [

--- a/luajit/luajit.json
+++ b/luajit/luajit.json
@@ -16,7 +16,7 @@
             "commit": "4182d6bf37e9f8d1cb5d6e83b1db66de84b95101",
             "x-checker-data": {
                 "type": "git",
-                "tag-pattern": "^v([\d.-]+)$",
+                "tag-pattern": "^v([\\d.-]+)$",
                 "stable-only": false
             }
         }


### PR DESCRIPTION
As the head developer of Luajit does not believe in the concept of releases, the only way to get a newish version of luajit is to use a snapshot of the repository's HEAD. 

v2.1.ROLLING is the 'newest' tag from the 2.1 series of luajit (dated august 2023), and includes a plethora of fixes and improvements.