### PR TITLE
SDL: Fix buffer overflow in SDL_LoadFunction()

### DIFF
--- a/SDL/SDL-1.2.15.json
+++ b/SDL/SDL-1.2.15.json
@@ -26,6 +26,10 @@
             "path": "sdl-check-for-SDL_VIDEO_X11_BACKINGSTORE.patch"
         },
         {
+            "type": "patch",
+            "path": "sdl-sysloadso-buffer-length.patch"
+        },
+        {
             "type": "script",
             "dest-filename": "autogen.sh",
             "commands": [

--- a/SDL/sdl-sysloadso-buffer-length.patch
+++ b/SDL/sdl-sysloadso-buffer-length.patch
@@ -1,0 +1,27 @@
+Origin: https://github.com/libsdl-org/SDL-1.2/commit/447ec3d2c360902aa648bec44b612a040248871e
+From: Ozkan Sezer <sezeroz@gmail.com>
+Description: loadso, dlsym, SDL_LoadFunction: cleanup the underscored name path.
+ - strlcpy was passed a wrong buffer length parameter. has worked so
+   far by luck.
+ - use memcpy instead of strlcpy for simplicity.
+ - 'append' has been a typo: should be 'prepend'.
+diff --git a/src/loadso/dlopen/SDL_sysloadso.c b/src/loadso/dlopen/SDL_sysloadso.c
+index 7985ee7f9..56331a1f0 100644
+--- a/src/loadso/dlopen/SDL_sysloadso.c
++++ b/src/loadso/dlopen/SDL_sysloadso.c
+@@ -45,11 +45,11 @@ void *SDL_LoadFunction(void *handle, const char *name)
+ {
+ 	void *symbol = dlsym(handle, name);
+ 	if ( symbol == NULL ) {
+-		/* append an underscore for platforms that need that. */
+-		size_t len = 1+SDL_strlen(name)+1;
+-		char *_name = SDL_stack_alloc(char, len);
++		/* prepend an underscore for platforms that need that. */
++		size_t len = SDL_strlen(name)+1;
++		char *_name = SDL_stack_alloc(char, len+1);
+ 		_name[0] = '_';
+-		SDL_strlcpy(&_name[1], name, len);
++		SDL_memcpy(&_name[1], name, len);
+ 		symbol = dlsym(handle, _name);
+ 		SDL_stack_free(_name);
+ 		if ( symbol == NULL ) {


### PR DESCRIPTION
While testing the 24.08 freedesktop runtime I noticed that SDL 1 crashes during initialization:

```
*** buffer overflow detected ***: terminated

Program received signal SIGABRT, Aborted.
0x00007ffff7572f24 in __pthread_kill_implementation () from /usr/lib/x86_64-linux-gnu/libc.so.6
(gdb) bt
#0  0x00007ffff7572f24 in __pthread_kill_implementation () from /usr/lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ffff751a08e in raise () from /usr/lib/x86_64-linux-gnu/libc.so.6
#2  0x00007ffff7501882 in abort () from /usr/lib/x86_64-linux-gnu/libc.so.6
#3  0x00007ffff75026e7 in __libc_message_impl.cold () from /usr/lib/x86_64-linux-gnu/libc.so.6
#4  0x00007ffff7601ee9 in __fortify_fail () from /usr/lib/x86_64-linux-gnu/libc.so.6
#5  0x00007ffff7601884 in __chk_fail () from /usr/lib/x86_64-linux-gnu/libc.so.6
#6  0x00007ffff7603339 in __strlcpy_chk () from /usr/lib/x86_64-linux-gnu/libc.so.6
#7  0x00007ffff7793df5 in strlcpy (__dest=0x7fffffffd4c1 "\261|\367\377\177", __src=0x7ffff77b82df "XMissingExtension", __n=<optimized out>) at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:168
#8  SDL_LoadFunction (handle=0x7ffff7fadaa0, name=name@entry=0x7ffff77b82df "XMissingExtension") at ./src/loadso/dlopen/SDL_sysloadso.c:52
#9  0x00007ffff7796cf9 in X11_GetSym (fnname=fnname@entry=0x7ffff77b82df "XMissingExtension", rc=rc@entry=0x7ffff77cb1bc <SDL_X11_HAVE_BASEXLIB>) at ./src/video/x11/SDL_x11dyn.c:71
#10 0x00007ffff779817e in SDL_X11_LoadSymbols () at ./src/video/x11/SDL_x11sym.h:74
#11 0x00007ffff779ed2c in X11_Available () at ./src/video/x11/SDL_x11video.c:77
#12 0x00007ffff778f954 in SDL_VideoInit (driver_name=0x0, flags=flags@entry=0) at ./src/video/SDL_video.c:193
#13 0x00007ffff776cd31 in SDL_InitSubSystem (flags=flags@entry=48) at ./src/SDL.c:89
#14 0x00007ffff776cde7 in SDL_Init (flags=flags@entry=48) at ./src/SDL.c:162
```

It turns out that `SDL_LoadFunction()` is creating a buffer that is too small, which just happened to work until now by chance, but crashes now presumably due to the toolchain changes in the new SDK. This has been fixed upstream in https://github.com/libsdl-org/SDL-1.2/commit/447ec3d2c360902aa648bec44b612a040248871e , and that's the patch that I'm cherry picking here.
