### PR TITLE
lzo: Cleanup /lib/pkgconfig/lzo2.pc

### DIFF
--- a/lzo/lzo.json
+++ b/lzo/lzo.json
@@ -2,7 +2,7 @@
     "name": "lzo",
     "cleanup": [
         "/include",
-        "/lib/*.so",
+        "/lib/pkgconfig",
         "/share/doc",
         "*.la"
     ],


### PR DESCRIPTION
Also don't cleanup /lib/*.so, we're just cleaning up a symlink to liblzo2.so.2.0.0 and as an independent module it should be shared.