### PR TITLE
mac: Set CMake install dirs

### DIFF
--- a/mac/mac.json
+++ b/mac/mac.json
@@ -1,6 +1,11 @@
 {
   "name": "libmac",
   "buildsystem": "cmake",
+  "config-opts": [
+    "-DCMAKE_INSTALL_BINDIR=bin",
+    "-DCMAKE_INSTALL_LIBDIR=lib",
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+  ],
   "cleanup": [
     "/include/MAC"
   ],


### PR DESCRIPTION
Without this, libMAC is installed in lib64 when building for x86-64 with Freedesktop SDK 24.08.