### PR TITLE
mac: Update to 10.76

### DIFF
--- a/mac/mac.json
+++ b/mac/mac.json
@@ -7,8 +7,8 @@
   "sources": [
     {
         "type": "archive",
-        "url": "https://freac.org/patches/MAC_920_SDK.zip",
-        "sha256": "54a99ff50b589d4afdb0e38aa86dba2c6a9fe1a086330209ecd563f09e46fd66",
+        "url": "https://freac.org/patches/MAC_1076_SDK.zip",
+        "sha256": "d0c8e69f2dbe337feb0d9e0a2a24e0bbb6f50613f0c88d0d0cf121cf603995d3",
         "strip-components": 0
     }
   ]


### PR DESCRIPTION
Update Monkey's Audio to latest release.

~~**Note:** Let's merge this after #332 please. I would like to re-release fre:ac 1.1.7 for the 24.08 runtime without updating Monkey's Audio.~~