### PR TITLE
Fix gzdoom crashing certain mods

### DIFF
--- a/gzdoom/zmusic.json
+++ b/gzdoom/zmusic.json
@@ -1,6 +1,9 @@
 {
     "name": "zmusic",
     "buildsystem": "cmake-ninja",
+    "build-options": {
+      "cxxflags": "-Wp,-U_GLIBCXX_ASSERTIONS"
+    },
     "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release"
     ],


### PR DESCRIPTION
For example, the mod "Doom 64: Unseen Evil (v1.03)" crashes when attempting to start a level without this fix.

Resolves https://github.com/ZDoom/gzdoom/issues/2834