### PR TITLE
physfs: Remove size property

### DIFF
--- a/physfs/physfs.json
+++ b/physfs/physfs.json
@@ -11,8 +11,7 @@
         {
             "type": "archive",
             "url": "https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2",
-            "sha256": "304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863",
-            "size": 194888
+            "sha256": "304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863"
         }
     ]
 }


### PR DESCRIPTION
Fixes the **flatpak-builder-lint** error:
```json
{
    "errors": [
        "manifest-unknown-properties"
    ],
    "info": [
        "manifest-unknown-properties: ['size']"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
```