### PR TITLE
Update dbus-glib to 0.114, add x-checker-data

### DIFF
--- a/dbus-glib/dbus-glib.json
+++ b/dbus-glib/dbus-glib.json
@@ -17,7 +17,12 @@
         {
             "type": "archive",
             "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.114.tar.gz",
-            "sha256": "c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c"
+            "sha256": "c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c",
+            "x-checker-data": {
+                "type": "anitya",
+                "project-id": 1979,
+                "url-template": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-$version.tar.gz"
+            }
         }
     ]
 }


### PR DESCRIPTION
Tested locally with `org.zotero.Zotero`, builds and works fine.