### PR TITLE
Update libinstpatch to 1.1.7

### DIFF
--- a/linux-audio/libinstpatch.json
+++ b/linux-audio/libinstpatch.json
@@ -1,9 +1,6 @@
 {
     "name": "libinstpatch",
     "buildsystem": "cmake-ninja",
-    "config-opts": [
-        "-DLIB_SUFFIX="
-    ],
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
@@ -12,8 +9,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/swami/libinstpatch/archive/v1.1.6.tar.gz",
-            "sha256": "8e9861b04ede275d712242664dab6ffa9166c7940fea3b017638681d25e10299"
+            "url": "https://github.com/swami/libinstpatch/archive/v1.1.7.tar.gz",
+            "sha256": "b388ab6f843559fc2da94837c37dfd4cf5973cf7cc2a0ce3cb33260b81377e9f"
         }
     ]
 }


### PR DESCRIPTION
Tested locally with `org.rncbc.qsynth`
config-opt `-DLIB_SUFFIX=` is no longer needed, as 1.1.7 uses GNUInstallDirs for installation paths