### PR TITLE
Add SDL2-image and SDL2-ttf

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,3 +24,4 @@ update-checker.sh  @flathub/reviewers
 /lzo/              @AKoskovich
 /squashfs-tools/   @AKoskovich
 /libayatana-appindicator/  @AKoskovich
+/SDL2/             @tothxa

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -1,6 +1,8 @@
 {
     "name": "SDL2_image",
-    "config-opts": ["--disable-static"],
+    "config-opts": [
+        "--disable-static"
+    ],
     "rm-configure": true,
     "cleanup": [
         "/include",
@@ -10,9 +12,10 @@
     ],
     "sources": [
         {
-            "type": "archive",
-            "url": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.8.tar.gz",
-            "sha256": "2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a",
+            "type": "git",
+            "url": "https://github.com/libsdl-org/SDL_image.git",
+            "tag": "release-2.8.8",
+            "commit": "c1bf2245b0ba63a25afe2f8574d305feca25af77",
             "x-checker-data": {
                 "type": "git",
                 "tag-pattern": "^release-(2\\.[\\d.]+)$"

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -3,30 +3,27 @@
     "config-opts": [
         "--disable-static"
     ],
-    "rm-configure": true,
     "cleanup": [
         "/include",
+        "/lib/cmake",
         "/lib/pkgconfig",
         "*.la",
         "*.a"
     ],
     "sources": [
         {
-            "type": "git",
-            "url": "https://github.com/libsdl-org/SDL_image.git",
-            "tag": "release-2.8.8",
-            "commit": "c1bf2245b0ba63a25afe2f8574d305feca25af77",
+            "type": "archive",
+            "url": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.8.tar.gz",
+            "sha256": "2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a",
             "x-checker-data": {
-                "type": "git",
-                "tag-pattern": "^release-(2\\.[\\d.]+)$"
+                "type": "anitya",
+                "project-id": 382729,
+                "stable-only": true,
+                "versions": {
+                    "<": "3.0.0"
+                },
+                "url-template": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$version.tar.gz"
             }
-        },
-        {
-            "type": "script",
-            "dest-filename": "autogen.sh",
-            "commands": [
-                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
-            ]
         }
     ]
 }

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -1,0 +1,25 @@
+{
+    "name": "SDL2_image",
+    "config-opts": ["--disable-static"],
+    "rm-configure": true,
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.8.tar.gz",
+            "sha256": "2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a"
+        },
+        {
+            "type": "script",
+            "dest-filename": "autogen.sh",
+            "commands": [
+                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+            ]
+        }
+    ]
+}

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -2,8 +2,8 @@
     "name": "SDL2_image",
     "cleanup": [
         "/include",
-        "/lib64/cmake",
-        "/lib64/pkgconfig"
+        "/lib/cmake",
+        "/lib/pkgconfig"
     ],
     "buildsystem": "cmake-ninja",
     "builddir": true,

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -1,5 +1,9 @@
 {
     "name": "SDL2_image",
+    "config-opts": [
+        "-DSDL2IMAGE_DEPS_SHARED=OFF",
+        "-DSDL2IMAGE_STRICT=ON"
+    ],
     "cleanup": [
         "/include",
         "/lib/cmake",
@@ -10,13 +14,13 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.8.tar.gz",
+            "url": "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-2.8.8.tar.gz",
             "sha256": "2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 382729,
                 "stable-only": true,
-                "url-template": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$version.tar.gz"
+                "url-template": "https://github.com/libsdl-org/SDL_image/releases/download/release-$version/SDL2_image-$version.tar.gz"
             }
         }
     ]

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -1,15 +1,12 @@
 {
     "name": "SDL2_image",
-    "config-opts": [
-        "--disable-static"
-    ],
     "cleanup": [
         "/include",
-        "/lib/cmake",
-        "/lib/pkgconfig",
-        "*.la",
-        "*.a"
+        "/lib64/cmake",
+        "/lib64/pkgconfig"
     ],
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
     "sources": [
         {
             "type": "archive",
@@ -19,9 +16,6 @@
                 "type": "anitya",
                 "project-id": 382729,
                 "stable-only": true,
-                "versions": {
-                    "<": "3.0.0"
-                },
                 "url-template": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$version.tar.gz"
             }
         }

--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -12,7 +12,11 @@
         {
             "type": "archive",
             "url": "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.8.tar.gz",
-            "sha256": "2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a"
+            "sha256": "2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a",
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^release-(2\\.[\\d.]+)$"
+            }
         },
         {
             "type": "script",

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -4,30 +4,27 @@
         "--disable-static",
         "ac_cv_path_FREETYPE_CONFIG=pkg-config freetype2"
     ],
-    "rm-configure": true,
     "cleanup": [
         "/include",
+        "/lib/cmake",
         "/lib/pkgconfig",
         "*.la",
         "*.a"
     ],
     "sources": [
         {
-            "type": "git",
-            "url": "https://github.com/libsdl-org/SDL_ttf.git",
-            "tag": "release-2.24.0",
-            "commit": "2a891473eaf05ba1707a4b7913e6c4db7de7458a",
+            "type": "archive",
+            "url": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.24.0.tar.gz",
+            "sha256": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd",
             "x-checker-data": {
-                "type": "git",
-                "tag-pattern": "^release-(2\\.[\\d.]+)$"
+                "type": "anitya",
+                "project-id": 4784,
+                "stable-only": true,
+                "versions": {
+                    "<": "3.0.0"
+                },
+                "url-template": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$version.tar.gz"
             }
-        },
-        {
-            "type": "script",
-            "dest-filename": "autogen.sh",
-            "commands": [
-                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
-            ]
         }
     ]
 }

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -1,0 +1,28 @@
+{
+    "name": "SDL2_ttf",
+    "config-opts": ["--disable-static"],
+    "rm-configure": true,
+    "config-opts": [
+        "ac_cv_path_FREETYPE_CONFIG=pkg-config freetype2"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.24.0.tar.gz",
+            "sha256": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd"
+        },
+        {
+            "type": "script",
+            "dest-filename": "autogen.sh",
+            "commands": [
+                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+            ]
+        }
+    ]
+}

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -13,7 +13,7 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.24.0.tar.gz",
+            "url": "https://github.com/libsdl-org/SDL_ttf/releases/download/release-2.24.0/SDL2_ttf-2.24.0.tar.gz",
             "sha256": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd",
             "x-checker-data": {
                 "type": "anitya",
@@ -22,7 +22,7 @@
                 "versions": {
                     "<": "3.0.0"
                 },
-                "url-template": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$version.tar.gz"
+                "url-template": "https://github.com/libsdl-org/SDL_ttf/releases/download/release-$version/SDL2_ttf-$version.tar.gz"
             }
         }
     ]

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -1,10 +1,10 @@
 {
     "name": "SDL2_ttf",
-    "config-opts": ["--disable-static"],
-    "rm-configure": true,
     "config-opts": [
+        "--disable-static",
         "ac_cv_path_FREETYPE_CONFIG=pkg-config freetype2"
     ],
+    "rm-configure": true,
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
@@ -13,9 +13,10 @@
     ],
     "sources": [
         {
-            "type": "archive",
-            "url": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.24.0.tar.gz",
-            "sha256": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd",
+            "type": "git",
+            "url": "https://github.com/libsdl-org/SDL_ttf.git",
+            "tag": "release-2.24.0",
+            "commit": "2a891473eaf05ba1707a4b7913e6c4db7de7458a",
             "x-checker-data": {
                 "type": "git",
                 "tag-pattern": "^release-(2\\.[\\d.]+)$"

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -1,16 +1,15 @@
 {
     "name": "SDL2_ttf",
     "config-opts": [
-        "--disable-static",
-        "ac_cv_path_FREETYPE_CONFIG=pkg-config freetype2"
+        "-DSDL2TTF_HARFBUZZ=ON"
     ],
     "cleanup": [
         "/include",
-        "/lib/cmake",
-        "/lib/pkgconfig",
-        "*.la",
-        "*.a"
+        "/lib64/cmake",
+        "/lib64/pkgconfig"
     ],
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
     "sources": [
         {
             "type": "archive",

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -5,8 +5,8 @@
     ],
     "cleanup": [
         "/include",
-        "/lib64/cmake",
-        "/lib64/pkgconfig"
+        "/lib/cmake",
+        "/lib/pkgconfig"
     ],
     "buildsystem": "cmake-ninja",
     "builddir": true,

--- a/SDL2/SDL2_ttf.json
+++ b/SDL2/SDL2_ttf.json
@@ -15,7 +15,11 @@
         {
             "type": "archive",
             "url": "https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.24.0.tar.gz",
-            "sha256": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd"
+            "sha256": "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd",
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^release-(2\\.[\\d.]+)$"
+            }
         },
         {
             "type": "script",


### PR DESCRIPTION
These will be removed from the runtime in 25.08, but are likely required by many SDL2 apps. Feel free to postpone until the new runtime is released.

Tested at: https://github.com/flathub/org.widelands.Widelands/pull/80

I didn't add myself to `CODEOWNERS` because as I see it the `SDL1.2` modules don't have a maintainer either, and I don't think I'd be the right person.

Actually, I just took the old modules from the `SDL` directory and updated the versions. They just worked as far as I can tell.