### PR TITLE
Fix python 2.7

### DIFF
--- a/python2.7/python-2.7.json
+++ b/python2.7/python-2.7.json
@@ -7,6 +7,9 @@
             "sha256": "b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43"
         }
     ],
+    "build-options": {
+        "cflags": "-std=c18"
+    },
     "config-opts": [
         "--enable-shared",
         "--with-ensurepip=yes",
@@ -45,7 +48,7 @@
         "/lib/python*/tkinter*",
         "/lib/python*/turtle*",
         "/lib/python*/lib2to3*",
-        
+
         /* Static library */
         "/lib/python2.7/config/libpython2.7.a"
     ]


### PR DESCRIPTION
Force c18 standard as code doesn't build with c23 (the new default on 25.08)