### PR TITLE
Fix libmad build with Freedesktop SDK 25.08

### DIFF
--- a/libmad/libmad.json
+++ b/libmad/libmad.json
@@ -1,6 +1,9 @@
 {
   "name" : "libmad",
   "buildsystem": "cmake-ninja",
+  "config-opts": [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ],
   "sources": [
     {
       "type" : "archive",


### PR DESCRIPTION
There is also an [upstream commit](https://codeberg.org/tenacityteam/libmad/commit/326363f04e583b563f63941db3cf7f50e76aceb2) to fix that. I don't know if patching that is preferred in this case.