### PR TITLE
gtk2: Fix gtk2 and ibus issues for gcc15 in 25.08

### DIFF
--- a/gtk2/gtk2-gcc15.patch
+++ b/gtk2/gtk2-gcc15.patch
@@ -1,0 +1,250 @@
+diff --git a/gtk/gtkitemfactory.c b/gtk/gtkitemfactory.c
+index 6addff3b13..49a7a77d6d 100644
+--- a/gtk/gtkitemfactory.c
++++ b/gtk/gtkitemfactory.c
+@@ -1184,7 +1184,7 @@ gtk_item_factory_create_menu_entries (guint              n_entries,
+ 
+       entry.path = path;
+       entry.accelerator = entries[i].accelerator;
+-      entry.callback = entries[i].callback;
++      entry.callback = (GtkItemFactoryCallback) entries[i].callback;
+       entry.callback_action = 0;
+       if (g_pattern_match_string (pspec_separator, path))
+ 	entry.item_type = "<Separator>";
+diff --git a/tests/testgtk.c b/tests/testgtk.c
+index b7ea442827..8205596e33 100644
+--- a/tests/testgtk.c
++++ b/tests/testgtk.c
+@@ -4235,41 +4235,41 @@ dump_accels (gpointer             callback_data,
+ static GtkItemFactoryEntry menu_items[] =
+ {
+   { "/_File",                  NULL,         NULL,                  0, "<Branch>" },
+-  { "/File/tearoff1",          NULL,         gtk_ifactory_cb,       0, "<Tearoff>" },
+-  { "/File/_New",              NULL,         gtk_ifactory_cb,       0, "<StockItem>", GTK_STOCK_NEW },
+-  { "/File/_Open",             NULL,         gtk_ifactory_cb,       0, "<StockItem>", GTK_STOCK_OPEN },
+-  { "/File/_Save",             NULL,         gtk_ifactory_cb,       0, "<StockItem>", GTK_STOCK_SAVE },
+-  { "/File/Save _As...",       "<control>A", gtk_ifactory_cb,       0, "<StockItem>", GTK_STOCK_SAVE },
+-  { "/File/_Dump \"_Accels\"",  NULL,        dump_accels,           0 },
++  { "/File/tearoff1",          NULL,         G_CALLBACK (gtk_ifactory_cb),       0, "<Tearoff>" },
++  { "/File/_New",              NULL,         G_CALLBACK (gtk_ifactory_cb),       0, "<StockItem>", GTK_STOCK_NEW },
++  { "/File/_Open",             NULL,         G_CALLBACK (gtk_ifactory_cb),       0, "<StockItem>", GTK_STOCK_OPEN },
++  { "/File/_Save",             NULL,         G_CALLBACK (gtk_ifactory_cb),       0, "<StockItem>", GTK_STOCK_SAVE },
++  { "/File/Save _As...",       "<control>A", G_CALLBACK (gtk_ifactory_cb),       0, "<StockItem>", GTK_STOCK_SAVE },
++  { "/File/_Dump \"_Accels\"",  NULL,        G_CALLBACK (dump_accels),           0 },
+   { "/File/\\/Test__Escaping/And\\/\n\tWei\\\\rdly",
+-                                NULL,        gtk_ifactory_cb,       0 },
+-  { "/File/sep1",        NULL,               gtk_ifactory_cb,       0, "<Separator>" },
+-  { "/File/_Quit",       NULL,               gtk_ifactory_cb,       0, "<StockItem>", GTK_STOCK_QUIT },
++                                NULL,        G_CALLBACK (gtk_ifactory_cb),       0 },
++  { "/File/sep1",        NULL,               G_CALLBACK (gtk_ifactory_cb),       0, "<Separator>" },
++  { "/File/_Quit",       NULL,               G_CALLBACK (gtk_ifactory_cb),       0, "<StockItem>", GTK_STOCK_QUIT },
+ 
+   { "/_Preferences",     		NULL, 0,               0, "<Branch>" },
+   { "/_Preferences/_Color", 		NULL, 0,               0, "<Branch>" },
+-  { "/_Preferences/Color/_Red",      	NULL, gtk_ifactory_cb, 0, "<RadioItem>" },
+-  { "/_Preferences/Color/_Green",   	NULL, gtk_ifactory_cb, 0, "/Preferences/Color/Red" },
+-  { "/_Preferences/Color/_Blue",        NULL, gtk_ifactory_cb, 0, "/Preferences/Color/Red" },
++  { "/_Preferences/Color/_Red",      	NULL, G_CALLBACK (gtk_ifactory_cb), 0, "<RadioItem>" },
++  { "/_Preferences/Color/_Green",   	NULL, G_CALLBACK (gtk_ifactory_cb), 0, "/Preferences/Color/Red" },
++  { "/_Preferences/Color/_Blue",        NULL, G_CALLBACK (gtk_ifactory_cb), 0, "/Preferences/Color/Red" },
+   { "/_Preferences/_Shape", 		NULL, 0,               0, "<Branch>" },
+-  { "/_Preferences/Shape/_Square",      NULL, gtk_ifactory_cb, 0, "<RadioItem>" },
+-  { "/_Preferences/Shape/_Rectangle",   NULL, gtk_ifactory_cb, 0, "/Preferences/Shape/Square" },
+-  { "/_Preferences/Shape/_Oval",        NULL, gtk_ifactory_cb, 0, "/Preferences/Shape/Rectangle" },
+-  { "/_Preferences/Shape/_Rectangle",   NULL, gtk_ifactory_cb, 0, "/Preferences/Shape/Square" },
+-  { "/_Preferences/Shape/_Oval",        NULL, gtk_ifactory_cb, 0, "/Preferences/Shape/Rectangle" },
+-  { "/_Preferences/Shape/_Image",       NULL, gtk_ifactory_cb, 0, "<ImageItem>", apple },
+-  { "/_Preferences/Coffee",                  NULL, gtk_ifactory_cb, 0, "<CheckItem>" },
+-  { "/_Preferences/Toast",                   NULL, gtk_ifactory_cb, 0, "<CheckItem>" },
+-  { "/_Preferences/Marshmallow Froot Loops", NULL, gtk_ifactory_cb, 0, "<CheckItem>" },
++  { "/_Preferences/Shape/_Square",      NULL, G_CALLBACK (gtk_ifactory_cb), 0, "<RadioItem>" },
++  { "/_Preferences/Shape/_Rectangle",   NULL, G_CALLBACK (gtk_ifactory_cb), 0, "/Preferences/Shape/Square" },
++  { "/_Preferences/Shape/_Oval",        NULL, G_CALLBACK (gtk_ifactory_cb), 0, "/Preferences/Shape/Rectangle" },
++  { "/_Preferences/Shape/_Rectangle",   NULL, G_CALLBACK (gtk_ifactory_cb), 0, "/Preferences/Shape/Square" },
++  { "/_Preferences/Shape/_Oval",        NULL, G_CALLBACK (gtk_ifactory_cb), 0, "/Preferences/Shape/Rectangle" },
++  { "/_Preferences/Shape/_Image",       NULL, G_CALLBACK (gtk_ifactory_cb), 0, "<ImageItem>", apple },
++  { "/_Preferences/Coffee",                  NULL, G_CALLBACK (gtk_ifactory_cb), 0, "<CheckItem>" },
++  { "/_Preferences/Toast",                   NULL, G_CALLBACK (gtk_ifactory_cb), 0, "<CheckItem>" },
++  { "/_Preferences/Marshmallow Froot Loops", NULL, G_CALLBACK (gtk_ifactory_cb), 0, "<CheckItem>" },
+ 
+   /* For testing deletion of menus */
+   { "/_Preferences/Should_NotAppear",          NULL, 0,               0, "<Branch>" },
+-  { "/Preferences/ShouldNotAppear/SubItem1",   NULL, gtk_ifactory_cb, 0 },
+-  { "/Preferences/ShouldNotAppear/SubItem2",   NULL, gtk_ifactory_cb, 0 },
++  { "/Preferences/ShouldNotAppear/SubItem1",   NULL, G_CALLBACK (gtk_ifactory_cb), 0 },
++  { "/Preferences/ShouldNotAppear/SubItem2",   NULL, G_CALLBACK (gtk_ifactory_cb), 0 },
+ 
+   { "/_Help",            NULL,         0,                     0, "<LastBranch>" },
+-  { "/Help/_Help",       NULL,         gtk_ifactory_cb,       0, "<StockItem>", GTK_STOCK_HELP},
+-  { "/Help/_About",      NULL,         gtk_ifactory_cb,       0 },
++  { "/Help/_Help",       NULL,         G_CALLBACK (gtk_ifactory_cb),       0, "<StockItem>", GTK_STOCK_HELP},
++  { "/Help/_About",      NULL,         G_CALLBACK (gtk_ifactory_cb),       0 },
+ };
+ 
+ 
+diff --git a/tests/testsocket.c b/tests/testsocket.c
+index 6801e09762..80144d3382 100644
+--- a/tests/testsocket.c
++++ b/tests/testsocket.c
+@@ -65,7 +65,7 @@ quit_cb (gpointer        callback_data,
+ static GtkItemFactoryEntry menu_items[] =
+ {
+   { "/_File",            NULL,         NULL,                  0, "<Branch>" },
+-  { "/File/_Quit",       "<control>Q", quit_cb,               0 },
++  { "/File/_Quit",       "<control>Q", G_CALLBACK (quit_cb),               0 },
+ };
+ 
+ static void
+diff --git a/tests/testsocket_common.c b/tests/testsocket_common.c
+index 1a4fece2a0..0af105e549 100644
+--- a/tests/testsocket_common.c
++++ b/tests/testsocket_common.c
+@@ -62,13 +62,13 @@ print_hello (GtkWidget *w,
+ 
+ static GtkItemFactoryEntry menu_items[] = {
+   { "/_File",         NULL,         NULL,           0, "<Branch>" },
+-  { "/File/_New",     "<control>N", print_hello,    ACTION_FILE_NEW, "<Item>" },
+-  { "/File/_Open",    "<control>O", print_hello,    ACTION_FILE_OPEN, "<Item>" },
++  { "/File/_New",     "<control>N", G_CALLBACK (print_hello),    ACTION_FILE_NEW, "<Item>" },
++  { "/File/_Open",    "<control>O", G_CALLBACK (print_hello),    ACTION_FILE_OPEN, "<Item>" },
+   { "/File/sep1",     NULL,         NULL,           0, "<Separator>" },
+-  { "/File/Quit",     "<control>Q", gtk_main_quit,  0, "<Item>" },
+-  { "/O_K",            "<control>K",print_hello,    ACTION_OK, "<Item>" },
++  { "/File/Quit",     "<control>Q", G_CALLBACK (gtk_main_quit),  0, "<Item>" },
++  { "/O_K",            "<control>K",G_CALLBACK (print_hello),    ACTION_OK, "<Item>" },
+   { "/_Help",         NULL,         NULL,           0, "<LastBranch>" },
+-  { "/_Help/About",   NULL,         print_hello,    ACTION_HELP_ABOUT, "<Item>" },
++  { "/_Help/About",   NULL,         G_CALLBACK (print_hello),    ACTION_HELP_ABOUT, "<Item>" },
+ };
+ 
+ static void
+diff --git a/tests/testtext.c b/tests/testtext.c
+index b9678bfc99..5d15bc254d 100644
+--- a/tests/testtext.c
++++ b/tests/testtext.c
+@@ -1946,69 +1946,68 @@ view_init_menus (View *view)
+     gtk_menu_item_activate (GTK_MENU_ITEM (menu_item));
+ }
+ 
+-static GtkItemFactoryEntry menu_items[] =
+-{
+-  { "/_File",            NULL,         NULL,        0, "<Branch>" },
+-  { "/File/_New",        "<control>N", do_new,      0, NULL },
+-  { "/File/New _View",   NULL,         do_new_view, 0, NULL },
+-  { "/File/_Open",       "<control>O", do_open,     0, NULL },
+-  { "/File/_Save",       "<control>S", do_save,     0, NULL },
+-  { "/File/Save _As...", NULL,         do_save_as,  0, NULL },
+-  { "/File/sep1",        NULL,         NULL,        0, "<Separator>" },
+-  { "/File/_Close",     "<control>W" , do_close,    0, NULL },
+-  { "/File/E_xit",      "<control>Q" , do_exit,     0, NULL },
++static GtkItemFactoryEntry menu_items[] = {
++  { "/_File", NULL, NULL, 0, "<Branch>" },
++  { "/File/_New", "<control>N", G_CALLBACK (do_new), 0, NULL },
++  { "/File/New _View", NULL, G_CALLBACK (do_new_view), 0, NULL },
++  { "/File/_Open", "<control>O", G_CALLBACK (do_open), 0, NULL },
++  { "/File/_Save", "<control>S", G_CALLBACK (do_save), 0, NULL },
++  { "/File/Save _As...", NULL, G_CALLBACK (do_save_as), 0, NULL },
++  { "/File/sep1", NULL, NULL, 0, "<Separator>" },
++  { "/File/_Close", "<control>W", G_CALLBACK (do_close), 0, NULL },
++  { "/File/E_xit", "<control>Q", G_CALLBACK (do_exit), 0, NULL },
+ 
+   { "/_Edit", NULL, 0, 0, "<Branch>" },
+-  { "/Edit/Copy", NULL, do_copy, 0, NULL },
++  { "/Edit/Copy", NULL, G_CALLBACK (do_copy), 0, NULL },
+   { "/Edit/sep1", NULL, NULL, 0, "<Separator>" },
+-  { "/Edit/Find...", NULL, do_search, 0, NULL },
+-  { "/Edit/Select All", "<control>A", do_select_all, 0, NULL }, 
++  { "/Edit/Find...", NULL, G_CALLBACK (do_search), 0, NULL },
++  { "/Edit/Select All", "<control>A", G_CALLBACK (do_select_all), 0, NULL },
+ 
+-  { "/_Settings",   	  NULL,         NULL,             0, "<Branch>" },
+-  { "/Settings/Wrap _Off",   NULL,      do_wrap_changed,  GTK_WRAP_NONE, "<RadioItem>" },
+-  { "/Settings/Wrap _Words", NULL,      do_wrap_changed,  GTK_WRAP_WORD, "/Settings/Wrap Off" },
+-  { "/Settings/Wrap _Chars", NULL,      do_wrap_changed,  GTK_WRAP_CHAR, "/Settings/Wrap Off" },
+-  { "/Settings/sep1",        NULL,      NULL,             0, "<Separator>" },
+-  { "/Settings/Editable", NULL,      do_editable_changed,  TRUE, "<RadioItem>" },
+-  { "/Settings/Not editable",    NULL,      do_editable_changed,  FALSE, "/Settings/Editable" },
+-  { "/Settings/sep1",        NULL,      NULL,             0, "<Separator>" },
++  { "/_Settings", NULL, NULL, 0, "<Branch>" },
++  { "/Settings/Wrap _Off", NULL, G_CALLBACK (do_wrap_changed), GTK_WRAP_NONE, "<RadioItem>" },
++  { "/Settings/Wrap _Words", NULL, G_CALLBACK (do_wrap_changed), GTK_WRAP_WORD, "/Settings/Wrap Off" },
++  { "/Settings/Wrap _Chars", NULL, G_CALLBACK (do_wrap_changed), GTK_WRAP_CHAR, "/Settings/Wrap Off" },
++  { "/Settings/sep1", NULL, NULL, 0, "<Separator>" },
++  { "/Settings/Editable", NULL, G_CALLBACK (do_editable_changed), TRUE, "<RadioItem>" },
++  { "/Settings/Not editable", NULL, G_CALLBACK (do_editable_changed), FALSE, "/Settings/Editable" },
++  { "/Settings/sep1", NULL, NULL, 0, "<Separator>" },
+ 
+-  { "/Settings/Cursor normal",    NULL,      do_cursor_visible_changed,  1, "<RadioItem>" },
+-  { "/Settings/Cursor not visible", NULL,      do_cursor_visible_changed,  0, "/Settings/Cursor normal" },
+-  { "/Settings/Cursor colored", NULL,      do_cursor_visible_changed,  2, "/Settings/Cursor normal" },
+-  { "/Settings/sep1",        NULL,      NULL,          0, "<Separator>" },
+-  
+-  { "/Settings/Left-to-Right", NULL,    do_direction_changed,  GTK_TEXT_DIR_LTR, "<RadioItem>" },
+-  { "/Settings/Right-to-Left", NULL,    do_direction_changed,  GTK_TEXT_DIR_RTL, "/Settings/Left-to-Right" },
++  { "/Settings/Cursor normal", NULL, G_CALLBACK (do_cursor_visible_changed), 1, "<RadioItem>" },
++  { "/Settings/Cursor not visible", NULL, G_CALLBACK (do_cursor_visible_changed), 0, "/Settings/Cursor normal" },
++  { "/Settings/Cursor colored", NULL, G_CALLBACK (do_cursor_visible_changed), 2, "/Settings/Cursor normal" },
++  { "/Settings/sep1", NULL, NULL, 0, "<Separator>" },
+ 
+-  { "/Settings/sep1",        NULL,      NULL,                0, "<Separator>" },
+-  { "/Settings/Sane spacing", NULL,    do_spacing_changed,  FALSE, "<RadioItem>" },
+-  { "/Settings/Funky spacing", NULL,    do_spacing_changed,  TRUE, "/Settings/Sane spacing" },
+-  { "/Settings/sep1",        NULL,      NULL,                0, "<Separator>" },
+-  { "/Settings/Don't cycle color tags", NULL,    do_color_cycle_changed,  FALSE, "<RadioItem>" },
+-  { "/Settings/Cycle colors", NULL,    do_color_cycle_changed,  TRUE, "/Settings/Don't cycle color tags" },
+-  { "/_Attributes",   	  NULL,         NULL,                0, "<Branch>" },
+-  { "/Attributes/Editable",   	  NULL,         do_apply_editable, TRUE, NULL },
+-  { "/Attributes/Not editable",   	  NULL,         do_apply_editable, FALSE, NULL },
+-  { "/Attributes/Invisible",   	  NULL,         do_apply_invisible, FALSE, NULL },
+-  { "/Attributes/Visible",   	  NULL,         do_apply_invisible, TRUE, NULL },
+-  { "/Attributes/Rise",   	  NULL,         do_apply_rise, FALSE, NULL },
+-  { "/Attributes/Large",   	  NULL,         do_apply_large, FALSE, NULL },
+-  { "/Attributes/Indent",   	  NULL,         do_apply_indent, FALSE, NULL },
+-  { "/Attributes/Margins",   	  NULL,         do_apply_margin, FALSE, NULL },
+-  { "/Attributes/Custom tabs",   	  NULL,         do_apply_tabs, FALSE, NULL },
+-  { "/Attributes/Default tabs",   	  NULL,         do_apply_tabs, TRUE, NULL },
+-  { "/Attributes/Color cycles",   	  NULL,         do_apply_colors, TRUE, NULL },
+-  { "/Attributes/No colors",   	          NULL,         do_apply_colors, FALSE, NULL },
+-  { "/Attributes/Remove all tags",        NULL, do_remove_tags, 0, NULL },
+-  { "/Attributes/Properties",             NULL, do_properties, 0, NULL },
+-  { "/Attributes/Rich Text copy & drag",  NULL, do_rich_text, 0, NULL },
+-  { "/Attributes/Rich Text paste & drop", NULL, do_rich_text, 1, NULL },
+-  { "/_Test",   	 NULL,         NULL,           0, "<Branch>" },
+-  { "/Test/_Example",  	 NULL,         do_example,  0, NULL },
+-  { "/Test/_Insert and scroll", NULL,         do_insert_and_scroll,  0, NULL },
+-  { "/Test/_Add fixed children", NULL,         do_add_children,  0, NULL },
+-  { "/Test/A_dd focusable children", NULL,    do_add_focus_children,  0, NULL },
++  { "/Settings/Left-to-Right", NULL, G_CALLBACK (do_direction_changed), GTK_TEXT_DIR_LTR, "<RadioItem>" },
++  { "/Settings/Right-to-Left", NULL, G_CALLBACK (do_direction_changed), GTK_TEXT_DIR_RTL, "/Settings/Left-to-Right" },
++
++  { "/Settings/sep1", NULL, NULL, 0, "<Separator>" },
++  { "/Settings/Sane spacing", NULL, G_CALLBACK (do_spacing_changed), FALSE, "<RadioItem>" },
++  { "/Settings/Funky spacing", NULL, G_CALLBACK (do_spacing_changed), TRUE, "/Settings/Sane spacing" },
++  { "/Settings/sep1", NULL, NULL, 0, "<Separator>" },
++  { "/Settings/Don't cycle color tags", NULL, G_CALLBACK (do_color_cycle_changed), FALSE, "<RadioItem>" },
++  { "/Settings/Cycle colors", NULL, G_CALLBACK (do_color_cycle_changed), TRUE, "/Settings/Don't cycle color tags" },
++  { "/_Attributes", NULL, NULL, 0, "<Branch>" },
++  { "/Attributes/Editable", NULL, G_CALLBACK (do_apply_editable), TRUE, NULL },
++  { "/Attributes/Not editable", NULL, G_CALLBACK (do_apply_editable), FALSE, NULL },
++  { "/Attributes/Invisible", NULL, G_CALLBACK (do_apply_invisible), FALSE, NULL },
++  { "/Attributes/Visible", NULL, G_CALLBACK (do_apply_invisible), TRUE, NULL },
++  { "/Attributes/Rise", NULL, G_CALLBACK (do_apply_rise), FALSE, NULL },
++  { "/Attributes/Large", NULL, G_CALLBACK (do_apply_large), FALSE, NULL },
++  { "/Attributes/Indent", NULL, G_CALLBACK (do_apply_indent), FALSE, NULL },
++  { "/Attributes/Margins", NULL, G_CALLBACK (do_apply_margin), FALSE, NULL },
++  { "/Attributes/Custom tabs", NULL, G_CALLBACK (do_apply_tabs), FALSE, NULL },
++  { "/Attributes/Default tabs", NULL, G_CALLBACK (do_apply_tabs), TRUE, NULL },
++  { "/Attributes/Color cycles", NULL, G_CALLBACK (do_apply_colors), TRUE, NULL },
++  { "/Attributes/No colors", NULL, G_CALLBACK (do_apply_colors), FALSE, NULL },
++  { "/Attributes/Remove all tags", NULL, G_CALLBACK (do_remove_tags), 0, NULL },
++  { "/Attributes/Properties", NULL, G_CALLBACK (do_properties), 0, NULL },
++  { "/Attributes/Rich Text copy & drag", NULL, G_CALLBACK (do_rich_text), 0, NULL },
++  { "/Attributes/Rich Text paste & drop", NULL, G_CALLBACK (do_rich_text), 1, NULL },
++  { "/_Test", NULL, NULL, 0, "<Branch>" },
++  { "/Test/_Example", NULL, G_CALLBACK (do_example), 0, NULL },
++  { "/Test/_Insert and scroll", NULL, G_CALLBACK (do_insert_and_scroll), 0, NULL },
++  { "/Test/_Add fixed children", NULL, G_CALLBACK (do_add_children), 0, NULL },
++  { "/Test/A_dd focusable children", NULL, G_CALLBACK (do_add_focus_children), 0, NULL },
+ };
+ 
+ static gboolean

--- a/gtk2/gtk2.json
+++ b/gtk2/gtk2.json
@@ -68,7 +68,8 @@
           "type": "patch",
           "paths": [
               "gtk2-fix-crash-in-show-uri.patch",
-              "gtk2-gcc14.patch"
+              "gtk2-gcc14.patch",
+              "gtk2-gcc15.patch"
           ]
         }
       ]
@@ -108,6 +109,10 @@
           "type": "archive",
           "url": "https://github.com/ibus/ibus/releases/download/1.5.23/ibus-1.5.23.tar.gz",
           "sha256": "b7e8d5bdb7d71a5ba4ee43cdf374675f77121a71c1679c9b9e7e02875bd0e150"
+        },
+        {
+          "type": "patch",
+          "path": "ibus-gcc15.patch"
         }
       ]
     }

--- a/gtk2/ibus-gcc15.patch
+++ b/gtk2/ibus-gcc15.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ibusenginesimple.c b/src/ibusenginesimple.c
+index 43bd5283..8896207e 100644
+--- a/src/ibusenginesimple.c
++++ b/src/ibusenginesimple.c
+@@ -542,7 +542,7 @@ check_emoji_table (IBusEngineSimple       *simple,
+         g_object_ref_sink (priv->lookup_table);
+     }
+     if (emoji_dict == NULL)
+-        emoji_dict = priv->emoji_dict = load_emoji_dict (simple);
++        emoji_dict = priv->emoji_dict = load_emoji_dict ();
+ 
+     if (emoji_dict == NULL || emoji_dict->dict == NULL)
+         return FALSE;


### PR DESCRIPTION
Building gtk2 with platform 25.08 fails when coercing `GtkItemFactoryCallback`s.
And ibus-gtk2 fails due to `load_emoji_dict` being called with one argument instead of none.

I've tested this with [ddrescueview](https://github.com/flathub/net.sourceforge.ddrescueview/).