### PR TITLE
physfs: Update to 3.2.0 and fix building with FreeDesktop SDK 25.08

### DIFF
--- a/physfs/physfs.json
+++ b/physfs/physfs.json
@@ -1,7 +1,7 @@
 {
     "name": "PhysicsFS",
     "buildsystem": "cmake-ninja",
-    "config-opts": [ "-DPHYSFS_BUILD_TEST=OFF", "-DPHYSFS_BUILD_STATIC=OFF" ],
+    "config-opts": [ "-DPHYSFS_BUILD_TEST=OFF", "-DPHYSFS_BUILD_STATIC=OFF", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ],
     "cleanup": [
         "/include",
         "/lib/pkgconfig",

--- a/physfs/physfs.json
+++ b/physfs/physfs.json
@@ -1,17 +1,26 @@
 {
-    "name": "PhysicsFS",
-    "buildsystem": "cmake-ninja",
-    "config-opts": [ "-DPHYSFS_BUILD_TEST=OFF", "-DPHYSFS_BUILD_STATIC=OFF", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/bin"
-    ],
-    "sources": [
-        {
-            "type": "archive",
-            "url": "https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2",
-            "sha256": "304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863"
-        }
-    ]
+  "name": "PhysicsFS",
+  "buildsystem": "cmake-ninja",
+  "config-opts": [
+    "-DPHYSFS_BUILD_TEST=OFF",
+    "-DPHYSFS_BUILD_STATIC=OFF",
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/bin"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/icculus/physfs.git",
+      "tag": "release-3.2.0",
+      "commit": "eb3383b532c5f74bfeb42ec306ba2cf80eed988c",
+      "x-checker-data": {
+        "type": "git",
+        "tag-pattern": "^release-([0-9.]+)$"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Passing in the config-opt: `"-DCMAKE_POLICY_VERSION_MINIMUM=3.5"` solves the build issue observed when using CMake 4.

I also went ahead and updated the version of physfs to 3.2.0. (up from 3.0.2) It looks like they have moved to Github from their old release location. 

I added an x-checker-data check for future updates which should help with the version falling behind again.