### PR TITLE
Revert "Include soundfont that is otherwise not bundled (#425)"

### DIFF
--- a/gzdoom/gzdoom.json
+++ b/gzdoom/gzdoom.json
@@ -30,8 +30,7 @@
         {
             "type": "shell",
             "commands": [
-                "sed -i \"s/org.zdoom.GZDoom/${FLATPAK_ID}/g\" src/d_iwad.cpp",
-                "install -D ./soundfont/gzdoom.sf2 /app/share/sounds/sf2/gzdoom.sf2"
+                "sed -i \"s/org.zdoom.GZDoom/${FLATPAK_ID}/g\" src/d_iwad.cpp"
             ]
         }
     ],


### PR DESCRIPTION
Was not required in the end. SF is just in a different folder