### PR TITLE
clutter: Fix cogl build

### DIFF
--- a/clutter/clutter.json
+++ b/clutter/clutter.json
@@ -13,6 +13,9 @@
     "modules": [
         {
             "name": "cogl",
+            "build-options": {
+                "cflags": "-std=gnu18"
+            },
             "config-opts": [
                 "--disable-cogl-gst",
                 "--disable-gtk-doc",


### PR DESCRIPTION
Force gnu18 standard as it fails in C23 the new default