### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .flatpak-builder/
+.DS_Store


### PR DESCRIPTION
This is a file that's usually created on MacOS when accessing the repository and contains information regarding finder settings for this directory. It can safely be ignored.