### PR TITLE
Update SDL2_image to 2.8.12

### DIFF
--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -14,8 +14,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.10/SDL2_image-2.8.10.tar.gz",
-            "sha256": "ebc059d01c007a62f4b04f10cf858527c875062532296943174df9a80264fd65",
+            "url": "https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.12/SDL2_image-2.8.12.tar.gz",
+            "sha256": "393f5efb50536ec13ca4f4affb69cc9966d3c3f969e6c5e701faddf9f9785381",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 382729,


### PR DESCRIPTION
Stable bugfix release: https://github.com/libsdl-org/SDL_image/releases/tag/release-2.8.12