### PR TITLE
SDL2_image: use libjpeg and libpng instead of stb_image

### DIFF
--- a/SDL2/SDL2_image.json
+++ b/SDL2/SDL2_image.json
@@ -1,6 +1,7 @@
 {
     "name": "SDL2_image",
     "config-opts": [
+        "-DSDL2IMAGE_BACKEND_STB=OFF",
         "-DSDL2IMAGE_DEPS_SHARED=OFF",
         "-DSDL2IMAGE_STRICT=ON"
     ],


### PR DESCRIPTION
stb_image is a public domain implementation of several image decoders in a single C header file. SDL2_image includes a copy of it and uses it by default for JPEG and PNG. A comment in stb_image says

  "Primarily of interest to game developers and other people who can
   avoid problematic images and only need the trivial interface"

Since the flatpak runtimes generally do include libjpeg and libpng, there is no reason to use a possibly limited implementation. It probably also receives less security testing than the de-facto standard libraries.