### PR TITLE
dbus-glib: add download mirrors

### DIFF
--- a/dbus-glib/dbus-glib.json
+++ b/dbus-glib/dbus-glib.json
@@ -18,6 +18,10 @@
         {
             "type": "archive",
             "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.114.tar.gz",
+            "mirror-urls": [
+                "https://deb.debian.org/debian/pool/main/d/dbus-glib/dbus-glib_0.114.orig.tar.gz",
+                "https://distfiles.alpinelinux.org/distfiles/edge/dbus-glib-0.114.tar.gz"
+            ],
             "sha256": "c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c",
             "x-checker-data": {
                 "type": "anitya",


### PR DESCRIPTION
dbus.freedesktop.org (annarchy.freedesktop.org, 131.252.210.176) has been timing out for several days, and this module has a single source URL, so every consumer of libappindicator fails at download-sources after a 60s stall per attempt.

This adds two mirrors, matching the style already used in intltool and libappindicator. Both currently serve the file and both match the pinned sha256 (737791 bytes, verified today):

- https://deb.debian.org/debian/pool/main/d/dbus-glib/dbus-glib_0.114.orig.tar.gz
- https://distfiles.alpinelinux.org/distfiles/edge/dbus-glib-0.114.tar.gz

No other change. The upstream URL stays primary and the checksum is untouched.